### PR TITLE
fix(seo): run-5 dogfood batch — titles, headings, alt text, contrast, trailing-slash

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -28,6 +28,17 @@
   --ui-radius: 0.625rem;
 }
 
+/* neutral-500 (text-muted) fails WCAG AA as text color on light surfaces
+   (4.37:1, needs 4.5:1); one shade darker clears it. Scoped to light mode:
+   dark surfaces already have enough contrast. NOTE: primary-500 also fails
+   as TEXT (2.47:1), but --ui-primary drives non-text surfaces sitewide
+   (CTA fills, badges, spotlight) — reassigning it is a brand-color change,
+   held for a design pass rather than shipped via a contrast ticket. */
+.light,
+:root:not(.dark) {
+  --ui-text-muted: var(--ui-color-neutral-600);
+}
+
 /* ------------------------------------------------------------------ */
 /* Theme signature utilities                                          */
 /* Verdant Console — warm developer console, emerald growth on olive  */

--- a/app/pages/get-started.vue
+++ b/app/pages/get-started.vue
@@ -5,6 +5,7 @@ definePageMeta({
 
 useSeoMeta({
   title: 'Get Started',
+  description: 'Connect your Google account or self-host Request Indexing to start submitting your pages to the Google Indexing API.',
 })
 
 const error = useRoute().query.error
@@ -12,6 +13,9 @@ const error = useRoute().query.error
 
 <template>
   <div class="px-5 py-10 flex flex-col gap-4 items-center justify-center">
+    <h1 class="text-2xl font-bold text-center">
+      Get Started with Request Indexing
+    </h1>
     <UAlert v-if="error === 'missing-scope'" variant="soft" title="Missing scope." color="warning" icon="i-heroicons-exclamation-triangle">
       <template #description>
         <div>

--- a/app/pages/guides.vue
+++ b/app/pages/guides.vue
@@ -43,6 +43,9 @@ const iconMap: Record<string, string> = {
 
 <template>
   <div>
+    <h1 class="sr-only">
+      Google Indexing API Guides
+    </h1>
     <UPageSection
       headline="Guides"
       title="Google Indexing API Guides"

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -2,8 +2,8 @@
 const { loggedIn, user } = useUserSession()
 
 useSeoMeta({
-  title: 'Request Indexing - Get Your Pages Indexed on Google Fast',
-  description: 'Free, open-source tool to request Google indexing for your pages using the Indexing API. View Search Console data, track indexing status, and retain historical data.',
+  title: 'Get Your Pages Indexed on Google Fast',
+  description: 'Free, open-source tool to request Google indexing for your pages via the Indexing API. Track status and view Search Console data.',
 })
 
 const faqItems = [
@@ -41,7 +41,7 @@ const mockUrls = [
 const mockSites = [
   { domain: 'nuxtseo.com', indexed: 91, total: 119 },
   { domain: 'harlanzw.com', indexed: 78, total: 112 },
-  { domain: 'docs.example.io', indexed: 54, total: 204 },
+  { domain: 'mdream.dev', indexed: 54, total: 204 },
 ]
 
 const walkthroughSteps = [
@@ -144,7 +144,7 @@ const marketingTools = [
                   <!-- Card header -->
                   <div class="px-5 py-4 border-b border-default flex items-center justify-between bg-elevated">
                     <div class="flex items-center gap-2.5">
-                      <img src="https://www.google.com/s2/favicons?domain=https://nuxtseo.com" alt="" class="size-4 rounded-sm">
+                      <img src="https://www.google.com/s2/favicons?domain=https://nuxtseo.com" alt="nuxtseo.com favicon" class="size-4 rounded-sm">
                       <span class="font-semibold text-default">nuxtseo.com</span>
                       <UBadge color="primary" variant="subtle" size="xs">
                         91% indexed
@@ -361,7 +361,7 @@ const marketingTools = [
                   </div>
                   <div class="divide-y divide-default">
                     <div v-for="site in mockSites" :key="site.domain" class="px-5 py-4 flex items-center gap-4 hover:bg-muted/60 transition-colors">
-                      <img :src="`https://www.google.com/s2/favicons?domain=${site.domain}&sz=64`" alt="" class="size-6 rounded shrink-0">
+                      <img :src="`https://www.google.com/s2/favicons?domain=${site.domain}&sz=64`" :alt="`${site.domain} favicon`" class="size-6 rounded shrink-0">
                       <div class="flex-1 min-w-0">
                         <div class="text-sm font-medium text-default truncate">
                           {{ site.domain }}

--- a/app/pages/privacy.vue
+++ b/app/pages/privacy.vue
@@ -1,3 +1,10 @@
+<script setup lang="ts">
+useSeoMeta({
+  title: 'Privacy Policy',
+  description: 'We value your privacy and want to be transparent about how we handle your information.',
+})
+</script>
+
 <template>
   <UContainer>
     <UPage>

--- a/app/pages/terms.vue
+++ b/app/pages/terms.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+useSeoMeta({
+  title: 'Terms of Service',
+  description: 'By accessing or using our service, you\'re agreeing to these terms, so please read them carefully.',
+})
 </script>
 
 <template>

--- a/app/pages/tools/bulk-indexing-checker.vue
+++ b/app/pages/tools/bulk-indexing-checker.vue
@@ -23,7 +23,7 @@ const faqs = [
 ]
 
 useToolSeo({
-  title: 'Bulk Indexing Checker — Audit Your Site\'s Index Coverage',
+  title: 'Bulk Indexing Checker Tool',
   description: 'Check indexing status for up to 50 URLs at once. Paste URLs or provide your sitemap to audit Google index coverage in bulk. Free, no signup required.',
   faqs,
 })

--- a/app/pages/tools/google-indexing-checker.vue
+++ b/app/pages/tools/google-indexing-checker.vue
@@ -23,8 +23,8 @@ const faqs = [
 ]
 
 useToolSeo({
-  title: 'Google Index Checker — Is Your Page Indexed?',
-  description: 'Free tool to check if your URL is indexed by Google. Instantly verify your page appears in Google search results and get actionable recommendations to fix indexing issues.',
+  title: 'Google Index Checker',
+  description: 'Free tool to check if your URL is indexed by Google. Instantly verify your page appears in search results and get tips to fix indexing issues.',
   faqs,
 })
 

--- a/app/pages/tools/site-indexing-report.vue
+++ b/app/pages/tools/site-indexing-report.vue
@@ -27,8 +27,8 @@ const faqs = [
 ]
 
 useToolSeo({
-  title: 'Site Indexing Report — How Well Does Google Index Your Site?',
-  description: 'Get a free indexing health report for any domain. See estimated indexed pages, organic traffic, ranking keywords, and actionable recommendations to improve Google indexing.',
+  title: 'Site Indexing Report Tool',
+  description: 'Get a free indexing health report for any domain: estimated indexed pages, organic traffic, ranking keywords, and tips to improve Google indexing.',
   faqs,
 })
 

--- a/content/guides/bulk-submit-urls-google-indexing-api.md
+++ b/content/guides/bulk-submit-urls-google-indexing-api.md
@@ -1,6 +1,6 @@
 ---
-title: "How to Bulk Submit URLs to the Google Indexing API"
-description: "Submit hundreds of URLs to Google's Indexing API efficiently. Learn the batch endpoint format, build queue strategies in Node.js and Python, and manage quota across large sites."
+title: "Bulk Submit URLs to the Indexing API"
+description: "Submit hundreds of URLs to Google's Indexing API efficiently. Batch endpoint format, queue strategies in Node.js and Python, and quota management."
 navigation:
   order: 4
   icon: i-heroicons-arrow-up-tray

--- a/content/guides/google-indexing-api-node-js.md
+++ b/content/guides/google-indexing-api-node-js.md
@@ -1,6 +1,6 @@
 ---
-title: "Google Indexing API with Node.js: Complete Implementation Guide"
-description: "Implement the Google Indexing API in Node.js and TypeScript. Covers authentication, single URL submission, batch requests, error handling, and production-ready patterns."
+title: "Google Indexing API with Node.js"
+description: "Implement the Google Indexing API in Node.js. Covers authentication, single and batch URL submission, error handling, and production-ready patterns."
 navigation:
   order: 3
   icon: i-simple-icons-nodedotjs

--- a/content/guides/google-indexing-api-quota.md
+++ b/content/guides/google-indexing-api-quota.md
@@ -1,6 +1,6 @@
 ---
-title: "Google Indexing API Quota: Limits, Strategies & How to Request Increases"
-description: "Understand the Google Indexing API's 200/day default quota, how batch requests count, 429 error handling, quota increase process, and strategies for staying under the limit."
+title: "Google Indexing API Quota & Limits"
+description: "The Google Indexing API's 200/day quota: how batch requests count, 429 error handling, requesting increases, and staying under the limit."
 navigation:
   order: 6
   icon: i-heroicons-chart-bar

--- a/content/guides/google-indexing-api-tutorial.md
+++ b/content/guides/google-indexing-api-tutorial.md
@@ -1,6 +1,6 @@
 ---
-title: "Google Indexing API Tutorial: Step-by-Step Setup Guide"
-description: "Set up the Google Indexing API from scratch. Create a GCP project, enable the API, configure a service account, add it to Search Console, and make your first API call."
+title: "Google Indexing API Setup Tutorial"
+description: "Set up the Google Indexing API from scratch: create a GCP project, enable the API, configure a service account, and make your first call."
 navigation:
   order: 2
   icon: i-heroicons-academic-cap

--- a/content/guides/google-indexing-api.md
+++ b/content/guides/google-indexing-api.md
@@ -1,6 +1,6 @@
 ---
-title: "Google Indexing API: The Complete Guide (2026)"
-description: "Learn how the Google Indexing API works, set up authentication, submit URLs with code examples in curl, TypeScript and Python, understand quotas, and get pages indexed faster."
+title: "Google Indexing API: Complete Guide"
+description: "Learn how the Google Indexing API works: authentication, code examples in curl, TypeScript and Python, quotas, and getting pages indexed faster."
 navigation:
   order: 1
   icon: i-heroicons-book-open

--- a/content/guides/indexing-api-for-blog-posts.md
+++ b/content/guides/indexing-api-for-blog-posts.md
@@ -1,6 +1,6 @@
 ---
-title: "Using the Indexing API for Blog Posts: Risks, Warnings & Best Practices"
-description: "Should you use Google's Indexing API for blog posts? Understand Google's official stance, warnings from Googlers, community experiences, real risks, and safer alternatives."
+title: "Indexing API for Blog Posts: Risks"
+description: "Should you use Google's Indexing API for blog posts? Google's official stance, warnings from Googlers, real risks, and safer alternatives."
 navigation:
   order: 5
   icon: i-heroicons-exclamation-triangle

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,6 +5,7 @@ main = ".output/server/index.mjs"
 
 [assets]
 directory = ".output/public"
+html_handling = "drop-trailing-slash"
 
 [[d1_databases]]
 binding = "DB"


### PR DESCRIPTION
Nuxt SEO Pro mcp-dogfood run 5: an autonomous worker fixed the site's open tickets in this isolated worktree; an independent verification pass reconciled every ledger claim against the diff (all 10 verified, zero commit-rule violations, no out-of-tree edits).

## What's in here (all SAFE-ranked at verification)
- **14 pages' titles/descriptions under the 60-char budget** — the "5 pages earning fewer clicks than expected" ticket's real root cause was the titleTemplate suffix pushing everything over; fixed as one batch instead of per-ticket.
- **`<h1>` on /get-started (visible) and /guides (sr-only)**.
- **Homepage mock favicon**: `docs.example.io` placeholder → `mdream.dev` (kills the s2/favicons 404 and its console error), plus real alt text on the favicon imgs.
- **`--ui-text-muted` darkened one shade in light mode** (4.37:1 → AA-passing).

## Two things to eyeball before/at merge
1. **`wrangler.toml` `html_handling = "drop-trailing-slash"`** — fixes the sitewide 307 redirect loop on prerendered pages. Logic matches Cloudflare's documented static-assets behavior and only governs HTML trailing-slash direction (not hashed assets), but the worker could not build-verify it (unrelated dep breakage in the tree). Curl a preview deploy: `/google-indexing-api`, `/privacy`, one `/_nuxt/*.js`, one image.
2. **`--ui-primary` reassignment was HELD OUT at verification** — the color-contrast ticket flagged primary-500 as failing text contrast, but the worker's fix (emerald-500 → emerald-800 on `--ui-primary`) would darken every primary CTA/badge/spotlight sitewide in light mode. That's a brand-color decision, not a contrast patch; the held hunk is documented in `main.css` for a design pass (contrast-safe text-only token is the likely shape).

Worker stats: 10 tickets — 7 fixed, 1 partial, 1 noise (bot-probe 404 correctly left alone), 3 mark_fixed claims filed with the product. $8.97.