### PR TITLE
chore: bump nuxt-domain-events to 0.0.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: 0.0.7
       version: 0.0.7
     '@harlan-zw/nuxt-domain-events':
-      specifier: 0.0.1
-      version: 0.0.1
+      specifier: 0.0.3
+      version: 0.0.3
     '@harlan-zw/nuxt-dx':
       specifier: 0.0.1
       version: 0.0.1
@@ -260,7 +260,7 @@ importers:
         version: 2.0.6(@cloudflare/workers-types@5.20260810.1)(@opentelemetry/api@1.9.1)(better-sqlite3@13.0.3)(valibot@1.4.2(typescript@6.0.3))
       '@harlan-zw/nuxt-domain-events':
         specifier: 'catalog:'
-        version: 0.0.1(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(3b78b38175d1b6794df87321ad9a5310))(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.27.3)(rolldown@1.2.3)(rollup@4.60.4)(vite@8.2.1(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.46.0)(tsx@4.23.11)(yaml@2.9.0)))
+        version: 0.0.3(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(3b78b38175d1b6794df87321ad9a5310))(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.27.3)(rolldown@1.2.3)(rollup@4.60.4)(vite@8.2.1(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.46.0)(tsx@4.23.11)(yaml@2.9.0)))
       '@harlan-zw/nuxt-use-query':
         specifier: 'catalog:'
         version: 0.0.1(better-sqlite3@13.0.3)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260810.1)(@opentelemetry/api@1.9.1)(better-sqlite3@13.0.3))(esbuild@0.27.3)(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(3b78b38175d1b6794df87321ad9a5310))(rolldown@1.2.3)(rollup@4.60.4)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.27.3)(rolldown@1.2.3)(rollup@4.60.4)(vite@8.2.1(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.46.0)(tsx@4.23.11)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.46.0)(tsx@4.23.11)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))(zod@4.4.3)
@@ -1638,8 +1638,8 @@ packages:
       nuxt: '>=4.5.0 <5.0.0'
       wrangler: '>=4.120.0 <5.0.0'
 
-  '@harlan-zw/nuxt-domain-events@0.0.1':
-    resolution: {integrity: sha512-fa19/jOtRl78ljC00VHEU3detrz50BwFDWHNJCBoIGCtovuAFKKd9Pu9YxhwDCo4LPydTbG40anyHPhNUTeGfw==}
+  '@harlan-zw/nuxt-domain-events@0.0.3':
+    resolution: {integrity: sha512-+lAmQB9MH1rDgF3brLpvYSVGKNAJ2PwrJV3+77V4PdFKUpzjsbI0s/+NypV7dIixqk8ua7E5zCnkM8EWAk1UBw==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@harlan-zw/nuxt-cf-jobs': 0.0.1
@@ -10544,7 +10544,7 @@ snapshots:
       - webpack
       - xml2js
 
-  '@harlan-zw/nuxt-domain-events@0.0.1(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(3b78b38175d1b6794df87321ad9a5310))(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.27.3)(rolldown@1.2.3)(rollup@4.60.4)(vite@8.2.1(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.46.0)(tsx@4.23.11)(yaml@2.9.0)))':
+  '@harlan-zw/nuxt-domain-events@0.0.3(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(3b78b38175d1b6794df87321ad9a5310))(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.27.3)(rolldown@1.2.3)(rollup@4.60.4)(vite@8.2.1(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.46.0)(tsx@4.23.11)(yaml@2.9.0)))':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.27.3)(rolldown@1.2.3)(rollup@4.60.4)(vite@8.2.1(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.46.0)(tsx@4.23.11)(yaml@2.9.0)))
       nuxt: 4.5.2(3b78b38175d1b6794df87321ad9a5310)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 minimumReleaseAgeExclude:
   - nuxt-ai-ready@1.7.9
   - '@harlan-zw/nuxt-cloudflare'
-  - '@harlan-zw/nuxt-domain-events@0.0.1'
+  - '@harlan-zw/nuxt-domain-events@0.0.1 || 0.0.3'
   - '@harlan-zw/nuxt-dx@0.0.1'
   - '@harlan-zw/nuxt-use-query@0.0.1'
   - nuxt-skew-protection@1.4.3
@@ -52,7 +52,7 @@ catalog:
   '@gscdump/engine': ^2.0.6
   '@gscdump/sdk': ^2.0.6
   '@harlan-zw/nuxt-cloudflare': 0.0.7
-  '@harlan-zw/nuxt-domain-events': 0.0.1
+  '@harlan-zw/nuxt-domain-events': 0.0.3
   '@harlan-zw/nuxt-dx': 0.0.1
   '@harlan-zw/nuxt-use-query': 0.0.1
   '@iconify-json/carbon': ^1.2.25


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Bump @harlan-zw/nuxt-domain-events to 0.0.3. This version generates #domain-events/server declarations for Nuxt consumers.