### PR TITLE
feat(observability): add wide request events

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -42,6 +42,7 @@ export default defineNuxtConfig({
     '@harlan-zw/nuxt-domain-events',
     '@harlan-zw/nuxt-use-query',
     '@harlan-zw/nuxt-cloudflare',
+    '@harlan-zw/nuxt-wide-events',
     '@harlan-zw/nuxt-dx',
     'nuxt-auth-utils',
     '@nuxt/image',
@@ -78,6 +79,18 @@ export default defineNuxtConfig({
   nuxtCloudflare: {
     kvCache: { binding: 'CACHE' },
     requiredSecrets: CLOUDFLARE_REQUIRED_SECRETS,
+  },
+
+  wideEvents: {
+    service: 'request-indexing',
+    request: true,
+    fields: [],
+    exclude: [
+      '/__nuxt_content/**',
+      '/_ipx/**',
+      '/_nuxt/**',
+      '/api/_nuxt_icon/**',
+    ],
   },
 
   domainEvents: {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@gscdump/sdk": "catalog:",
     "@harlan-zw/nuxt-domain-events": "catalog:",
     "@harlan-zw/nuxt-use-query": "catalog:",
+    "@harlan-zw/nuxt-wide-events": "catalog:",
     "@iconify-json/carbon": "catalog:",
     "@iconify-json/circle-flags": "catalog:",
     "@iconify-json/heroicons": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ catalogs:
     '@harlan-zw/nuxt-use-query':
       specifier: 0.0.1
       version: 0.0.1
+    '@harlan-zw/nuxt-wide-events':
+      specifier: 0.0.1
+      version: 0.0.1
     '@iconify-json/carbon':
       specifier: ^1.2.25
       version: 1.2.25
@@ -264,6 +267,9 @@ importers:
       '@harlan-zw/nuxt-use-query':
         specifier: 'catalog:'
         version: 0.0.1(better-sqlite3@13.0.3)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260812.1)(@opentelemetry/api@1.9.1)(better-sqlite3@13.0.3))(esbuild@0.27.3)(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(e30e7a2099f54b4b5af713a36ab73386))(rolldown@1.2.3)(rollup@4.60.4)(srvx@0.12.5)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.27.3)(rolldown@1.2.3)(rollup@4.60.4)(vite@8.2.1(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.11)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.11)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))(zod@4.4.3)
+      '@harlan-zw/nuxt-wide-events':
+        specifier: 'catalog:'
+        version: 0.0.1(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.7.0)(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(e30e7a2099f54b4b5af713a36ab73386))(oxc-parser@0.144.0)(rolldown@1.2.3)(terser@5.50.0)(tsx@4.23.11)(unplugin@3.3.0(esbuild@0.27.3)(rolldown@1.2.3)(rollup@4.60.4)(vite@8.2.1(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.11)(yaml@2.9.0)))(yaml@2.9.0)
       '@iconify-json/carbon':
         specifier: 'catalog:'
         version: 1.2.25
@@ -1661,6 +1667,12 @@ packages:
     peerDependencies:
       nuxt: '>=4.5.0 <5.0.0'
       zod: ^4.0.0
+
+  '@harlan-zw/nuxt-wide-events@0.0.1':
+    resolution: {integrity: sha512-v4aZ1wLvLBkgDonskRTmGfsgbWyn//QanyMazOhak3tgQDXfuF8DjcFwEAH2ndVTmM9uekIMNUIvjYaa82SUSQ==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      nuxt: '>=4.5.0 <5.0.0'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -10795,6 +10807,31 @@ snapshots:
       - vue
       - webpack
       - xml2js
+
+  '@harlan-zw/nuxt-wide-events@0.0.1(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.7.0)(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(e30e7a2099f54b4b5af713a36ab73386))(oxc-parser@0.144.0)(rolldown@1.2.3)(terser@5.50.0)(tsx@4.23.11)(unplugin@3.3.0(esbuild@0.27.3)(rolldown@1.2.3)(rollup@4.60.4)(vite@8.2.1(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.11)(yaml@2.9.0)))(yaml@2.9.0)':
+    dependencies:
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.144.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.27.3)(rolldown@1.2.3)(rollup@4.60.4)(vite@8.2.1(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.11)(yaml@2.9.0)))
+      nuxt: 4.5.2(e30e7a2099f54b4b5af713a36ab73386)
+      pathe: 2.0.3
+      vite: 8.2.1(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.11)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - unplugin
+      - yaml
 
   '@humanfs/core@0.19.1': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ minimumReleaseAgeExclude:
   - '@harlan-zw/nuxt-domain-events@0.0.1 || 0.0.3'
   - '@harlan-zw/nuxt-dx@0.0.1'
   - '@harlan-zw/nuxt-use-query@0.0.1'
+  - '@harlan-zw/nuxt-wide-events@0.0.1'
   - nuxt-skew-protection@1.4.3
 
 shellEmulator: true
@@ -55,6 +56,7 @@ catalog:
   '@harlan-zw/nuxt-domain-events': 0.0.3
   '@harlan-zw/nuxt-dx': 0.0.6
   '@harlan-zw/nuxt-use-query': 0.0.1
+  '@harlan-zw/nuxt-wide-events': 0.0.1
   '@iconify-json/carbon': ^1.2.25
   '@iconify-json/circle-flags': ^1.2.10
   '@iconify-json/heroicons': ^1.2.3


### PR DESCRIPTION
## Summary

- emit one production wide event for each application request
- exclude internal Nuxt asset and content routes
- keep custom Fields empty so existing D1 and Sentry logging stay separate

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).