### PR TITLE
fix: keep local server errors out of Sentry

### DIFF
--- a/server/plugins/sentry.ts
+++ b/server/plugins/sentry.ts
@@ -1,15 +1,16 @@
 import { sentryCloudflareNitroPlugin } from '@sentry/nuxt/module/plugins'
-import { createSentryDataCollection, dropExpectedNotFound } from '../../shared/sentry'
+import { createSentryDataCollection, dropExpectedNotFound, resolveServerSentryInitialization } from '../../shared/sentry'
 
 export default defineNitroPlugin((nitroApp) => {
   const { sentry } = useRuntimeConfig()
-  if (!sentry.enabled || !sentry.dsn)
+  const initialization = resolveServerSentryInitialization(sentry)
+  if (initialization._tag === 'Disabled')
     return
 
   sentryCloudflareNitroPlugin({
-    dsn: sentry.dsn,
+    dsn: initialization.dsn,
     environment: sentry.environment,
-    release: sentry.release || undefined,
+    release: initialization.release,
     tracesSampleRate: sentry.tracesSampleRate,
     dataCollection: createSentryDataCollection(),
     beforeSend: dropExpectedNotFound,

--- a/shared/sentry.ts
+++ b/shared/sentry.ts
@@ -1,5 +1,30 @@
 export const SENTRY_DSN = 'https://285c1e24a3cb947359ebc30e95ad7746@o4510507748163584.ingest.us.sentry.io/4511887363080192'
 
+interface ServerSentryConfig {
+  enabled: boolean
+  dsn?: string
+  release?: string
+}
+
+export type ServerSentryInitialization
+  = | { _tag: 'Disabled', reason: 'disabled' | 'missing-dsn' | 'missing-release' }
+    | { _tag: 'Enabled', dsn: string, release: string }
+
+/**
+ * Local production-mode builds have no release ID. Keeping that state distinct
+ * prevents Wrangler preview failures from entering the production project.
+ */
+export function resolveServerSentryInitialization(config: ServerSentryConfig): ServerSentryInitialization {
+  if (!config.enabled)
+    return { _tag: 'Disabled', reason: 'disabled' }
+  if (!config.dsn)
+    return { _tag: 'Disabled', reason: 'missing-dsn' }
+  if (!config.release)
+    return { _tag: 'Disabled', reason: 'missing-release' }
+
+  return { _tag: 'Enabled', dsn: config.dsn, release: config.release }
+}
+
 export function createSentryDataCollection() {
   return {
     userInfo: false,

--- a/tests/sentry.test.ts
+++ b/tests/sentry.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, it } from 'vitest'
-import { dropExpectedNotFound, errorStatusCode } from '../shared/sentry'
+import { dropExpectedNotFound, errorStatusCode, resolveServerSentryInitialization } from '../shared/sentry'
+
+describe('resolveServerSentryInitialization', () => {
+  it('keeps an unversioned local build out of production Sentry', () => {
+    expect(resolveServerSentryInitialization({
+      enabled: true,
+      dsn: 'https://public@example.invalid/1',
+      release: '',
+    })).toEqual({ _tag: 'Disabled', reason: 'missing-release' })
+  })
+
+  it('enables a versioned production build', () => {
+    expect(resolveServerSentryInitialization({
+      enabled: true,
+      dsn: 'https://public@example.invalid/1',
+      release: 'abc123',
+    })).toEqual({
+      _tag: 'Enabled',
+      dsn: 'https://public@example.invalid/1',
+      release: 'abc123',
+    })
+  })
+})
 
 describe('errorStatusCode', () => {
   it('reads an h3 error status', () => {


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

REQUEST-INDEXING-C came from an unversioned local Wrangler build, but the server Sentry client sent it to the production project. Require a release ID before initialization, with regression coverage for local and deployed builds.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).