### PR TITLE
fix(sentry): only report from builds that carry a release

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -6,12 +6,17 @@ import { globbySync } from 'globby'
 import { withoutRollupPlugin } from './scripts/rollup-plugins'
 import { CLOUDFLARE_REQUIRED_SECRETS } from './shared/cloudflare'
 import { runtimeOnlyRouteRules } from './shared/routes'
-import { SENTRY_DSN } from './shared/sentry'
+import { resolveSentryTarget, SENTRY_DSN } from './shared/sentry'
 
 const tokens: Partial<OAuthPoolToken>[] = process.env.NUXT_OAUTH_POOL ? JSON.parse(process.env.NUXT_OAUTH_POOL) : []
 const hasSentryAuthToken = Boolean(process.env.SENTRY_AUTH_TOKEN)
   || existsSync('.env.sentry-build-plugin')
 const sentryRelease = process.env.SENTRY_RELEASE || process.env.GITHUB_SHA || undefined
+const sentryTarget = resolveSentryTarget({
+  nodeEnv: process.env.NODE_ENV,
+  release: sentryRelease,
+  environment: process.env.SENTRY_ENVIRONMENT,
+})
 
 // read all the folders at the server/app path
 const recursiveServerAppFolders = globbySync('**/*', {
@@ -364,14 +369,16 @@ export default defineNuxtConfig({
       adsClientId: '',
       adsClientSecret: '',
     },
-    sentry: {
-      dsn: SENTRY_DSN,
-      enabled: process.env.NODE_ENV === 'production',
-      environment: 'production',
-      release: sentryRelease ?? '',
-      tracesSampleRate: 0.05,
-    },
     public: {
+      // Public so the browser SDK and the Nitro plugin read one decision. The
+      // DSN is not a secret; it already ships in the client bundle.
+      sentry: {
+        dsn: SENTRY_DSN,
+        enabled: sentryTarget._tag === 'Enabled',
+        environment: sentryTarget._tag === 'Enabled' ? sentryTarget.environment : '',
+        release: sentryTarget._tag === 'Enabled' ? sentryTarget.release : '',
+        tracesSampleRate: 0.05,
+      },
       baseUrl: 'https://requestindexing.com',
       indexing: {
         usageLimitPerUser: 15,
@@ -383,7 +390,8 @@ export default defineNuxtConfig({
   },
 
   sentry: {
-    enabled: process.env.NODE_ENV === 'production',
+    // A build with no release never deployed, so it never instruments.
+    enabled: sentryTarget._tag === 'Enabled',
     org: 'harlan-zw',
     project: 'request-indexing',
     authToken: process.env.SENTRY_AUTH_TOKEN,

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,11 +1,19 @@
 import * as Sentry from '@sentry/nuxt'
-import { createSentryDataCollection, dropExpectedNotFound, SENTRY_DSN } from './shared/sentry'
+import { useRuntimeConfig } from '#imports'
+import { createSentryDataCollection, dropExpectedNotFound } from './shared/sentry'
 
-if (!import.meta.dev) {
+// The module wraps this file in a Nuxt plugin, so runtime config is available
+// here. Read the same decision the Nitro plugin reads: `import.meta.dev` alone
+// is false inside a local `wrangler dev` worker, which is how a laptop ended up
+// reporting as production.
+const { sentry } = useRuntimeConfig().public
+
+if (sentry.enabled && sentry.dsn) {
   Sentry.init({
-    dsn: SENTRY_DSN,
-    environment: 'production',
-    tracesSampleRate: 0.05,
+    dsn: sentry.dsn,
+    environment: sentry.environment,
+    release: sentry.release || undefined,
+    tracesSampleRate: sentry.tracesSampleRate,
     dataCollection: createSentryDataCollection(),
     beforeSend: dropExpectedNotFound,
     ignoreErrors: [

--- a/server/plugins/sentry.ts
+++ b/server/plugins/sentry.ts
@@ -2,7 +2,7 @@ import { sentryCloudflareNitroPlugin } from '@sentry/nuxt/module/plugins'
 import { createSentryDataCollection, dropExpectedNotFound } from '../../shared/sentry'
 
 export default defineNitroPlugin((nitroApp) => {
-  const { sentry } = useRuntimeConfig()
+  const { sentry } = useRuntimeConfig().public
   if (!sentry.enabled || !sentry.dsn)
     return
 

--- a/shared/sentry.ts
+++ b/shared/sentry.ts
@@ -1,5 +1,40 @@
 export const SENTRY_DSN = 'https://285c1e24a3cb947359ebc30e95ad7746@o4510507748163584.ingest.us.sentry.io/4511887363080192'
 
+/**
+ * Whether a build may report to Sentry, and under what identity.
+ *
+ * `Disabled` carries the reason so a build never silently loses reporting.
+ */
+export type SentryTarget
+  = | { _tag: 'Disabled', reason: 'development' | 'unreleased-build' }
+    | { _tag: 'Enabled', environment: string, release: string }
+
+/**
+ * `NODE_ENV === 'production'` is not proof of a deploy. `wrangler dev` and
+ * `nuxt preview` run the production build on a laptop, so a local worker used
+ * to report into the production project: REQUEST-INDEXING-C arrived from
+ * `.wrangler/tmp/dev-*` in a developer worktree, tagged `environment:production`
+ * and carrying no release, while every deployed event carries one.
+ *
+ * Only the deploy pipeline sets a release (`GITHUB_SHA` in the workflow, or an
+ * explicit `SENTRY_RELEASE`). Requiring one makes "reporting as production from
+ * a machine that never deployed" unrepresentable.
+ */
+export function resolveSentryTarget(input: {
+  nodeEnv?: string
+  release?: string
+  environment?: string
+}): SentryTarget {
+  if (input.nodeEnv !== 'production')
+    return { _tag: 'Disabled', reason: 'development' }
+
+  const release = input.release?.trim()
+  if (!release)
+    return { _tag: 'Disabled', reason: 'unreleased-build' }
+
+  return { _tag: 'Enabled', environment: input.environment?.trim() || 'production', release }
+}
+
 export function createSentryDataCollection() {
   return {
     userInfo: false,

--- a/tests/sentry.test.ts
+++ b/tests/sentry.test.ts
@@ -1,5 +1,31 @@
 import { describe, expect, it } from 'vitest'
-import { dropExpectedNotFound, errorStatusCode } from '../shared/sentry'
+import { dropExpectedNotFound, errorStatusCode, resolveSentryTarget } from '../shared/sentry'
+
+describe('resolveSentryTarget', () => {
+  it('reports a deployed build', () => {
+    expect(resolveSentryTarget({ nodeEnv: 'production', release: 'e75a05b0' }))
+      .toEqual({ _tag: 'Enabled', environment: 'production', release: 'e75a05b0' })
+  })
+
+  it('stays silent for a local production build with no release', () => {
+    expect(resolveSentryTarget({ nodeEnv: 'production', release: undefined }))
+      .toEqual({ _tag: 'Disabled', reason: 'unreleased-build' })
+    expect(resolveSentryTarget({ nodeEnv: 'production', release: '   ' }))
+      .toEqual({ _tag: 'Disabled', reason: 'unreleased-build' })
+  })
+
+  it('stays silent outside a production build', () => {
+    expect(resolveSentryTarget({ nodeEnv: 'development', release: 'e75a05b0' }))
+      .toEqual({ _tag: 'Disabled', reason: 'development' })
+    expect(resolveSentryTarget({}))
+      .toEqual({ _tag: 'Disabled', reason: 'development' })
+  })
+
+  it('takes the environment name from the deploy when one is given', () => {
+    expect(resolveSentryTarget({ nodeEnv: 'production', release: 'abc', environment: 'staging' }))
+      .toEqual({ _tag: 'Enabled', environment: 'staging', release: 'abc' })
+  })
+})
 
 describe('errorStatusCode', () => {
   it('reads an h3 error status', () => {


### PR DESCRIPTION
### Description

Sentry decided it was in production from `NODE_ENV` alone, and `environment` was hardcoded `'production'`. A production-mode build is not a deploy, so my own `wrangler dev` worker in a sibling worktree posted this into the production project:

```
Error: Empty password
  /home/harlan/sites/request-indexing.nuxt-wide-events/.wrangler/tmp/dev-0m1Moy/index.js  seal
  ...  getUserSession
environment: production      (no release tag)
```

That is a missing local `NUXT_SESSION_PASSWORD`, not a production fault, and it landed in the same inbox as real errors with laptop file paths attached.

`resolveSentryTarget` in `shared/sentry.ts` now returns `Enabled` only when the build is production *and* carries a release. The deploy workflow always has `GITHUB_SHA`, so real deploys are unaffected; a laptop can no longer produce an enabled build. The Sentry module, the Nitro plugin and the browser SDK all read that one decision, which meant moving the Sentry runtime config under `public` so `sentry.client.config.ts` can read it too (the module wraps that file in a Nuxt plugin, so `useRuntimeConfig()` works there).

Every deployed issue in the current Sentry backlog carries a release tag and this one does not, which is what the gate keys off. Worth knowing before merge: nothing else in the app reads `runtimeConfig.sentry`, and no `NUXT_SENTRY_*` override is set anywhere, so the move to `public` should be invisible. If a preview environment ever needs its own name, `SENTRY_ENVIRONMENT` is now honoured.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).