### PR TITLE
fix(sentry): stop the browser SDK reporting a local build as production

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -383,14 +383,16 @@ export default defineNuxtConfig({
       adsClientId: '',
       adsClientSecret: '',
     },
-    sentry: {
-      dsn: SENTRY_DSN,
-      enabled: process.env.NODE_ENV === 'production',
-      environment: 'production',
-      release: sentryRelease ?? '',
-      tracesSampleRate: 0.05,
-    },
     public: {
+      // Public so the Nitro plugin and the browser SDK read one decision. The
+      // DSN is not a secret; it already ships in the client bundle.
+      sentry: {
+        dsn: SENTRY_DSN,
+        enabled: process.env.NODE_ENV === 'production',
+        environment: process.env.SENTRY_ENVIRONMENT || 'production',
+        release: sentryRelease ?? '',
+        tracesSampleRate: 0.05,
+      },
       baseUrl: 'https://requestindexing.com',
       indexing: {
         usageLimitPerUser: 15,

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,11 +1,19 @@
 import * as Sentry from '@sentry/nuxt'
-import { createSentryDataCollection, dropExpectedNotFound, SENTRY_DSN } from './shared/sentry'
+import { useRuntimeConfig } from '#imports'
+import { createSentryDataCollection, dropExpectedNotFound, resolveSentryInitialization } from './shared/sentry'
 
-if (!import.meta.dev) {
+// The Sentry module wraps this file in a Nuxt plugin, so runtime config is
+// readable here. Read the same decision the Nitro plugin reads instead of
+// `import.meta.dev`, which is false inside a local `wrangler dev` worker.
+const { sentry } = useRuntimeConfig().public
+const initialization = resolveSentryInitialization(sentry)
+
+if (initialization._tag === 'Enabled') {
   Sentry.init({
-    dsn: SENTRY_DSN,
-    environment: 'production',
-    tracesSampleRate: 0.05,
+    dsn: initialization.dsn,
+    environment: initialization.environment,
+    release: initialization.release,
+    tracesSampleRate: sentry.tracesSampleRate,
     dataCollection: createSentryDataCollection(),
     beforeSend: dropExpectedNotFound,
     ignoreErrors: [

--- a/server/plugins/sentry.ts
+++ b/server/plugins/sentry.ts
@@ -1,15 +1,15 @@
 import { sentryCloudflareNitroPlugin } from '@sentry/nuxt/module/plugins'
-import { createSentryDataCollection, dropExpectedNotFound, resolveServerSentryInitialization } from '../../shared/sentry'
+import { createSentryDataCollection, dropExpectedNotFound, resolveSentryInitialization } from '../../shared/sentry'
 
 export default defineNitroPlugin((nitroApp) => {
-  const { sentry } = useRuntimeConfig()
-  const initialization = resolveServerSentryInitialization(sentry)
+  const { sentry } = useRuntimeConfig().public
+  const initialization = resolveSentryInitialization(sentry)
   if (initialization._tag === 'Disabled')
     return
 
   sentryCloudflareNitroPlugin({
     dsn: initialization.dsn,
-    environment: sentry.environment,
+    environment: initialization.environment,
     release: initialization.release,
     tracesSampleRate: sentry.tracesSampleRate,
     dataCollection: createSentryDataCollection(),

--- a/shared/sentry.ts
+++ b/shared/sentry.ts
@@ -1,20 +1,26 @@
 export const SENTRY_DSN = 'https://285c1e24a3cb947359ebc30e95ad7746@o4510507748163584.ingest.us.sentry.io/4511887363080192'
 
-interface ServerSentryConfig {
+interface SentryConfig {
   enabled: boolean
   dsn?: string
   release?: string
+  environment?: string
 }
 
-export type ServerSentryInitialization
+export type SentryInitialization
   = | { _tag: 'Disabled', reason: 'disabled' | 'missing-dsn' | 'missing-release' }
-    | { _tag: 'Enabled', dsn: string, release: string }
+    | { _tag: 'Enabled', dsn: string, release: string, environment: string }
 
 /**
  * Local production-mode builds have no release ID. Keeping that state distinct
  * prevents Wrangler preview failures from entering the production project.
+ *
+ * The browser SDK reads this too. It used to gate on `import.meta.dev` alone,
+ * which is false inside a local `wrangler dev` worker, so a laptop could still
+ * report as production. Carrying `environment` through the same result keeps
+ * that name out of the init call sites, where it was hardcoded.
  */
-export function resolveServerSentryInitialization(config: ServerSentryConfig): ServerSentryInitialization {
+export function resolveSentryInitialization(config: SentryConfig): SentryInitialization {
   if (!config.enabled)
     return { _tag: 'Disabled', reason: 'disabled' }
   if (!config.dsn)
@@ -22,7 +28,12 @@ export function resolveServerSentryInitialization(config: ServerSentryConfig): S
   if (!config.release)
     return { _tag: 'Disabled', reason: 'missing-release' }
 
-  return { _tag: 'Enabled', dsn: config.dsn, release: config.release }
+  return {
+    _tag: 'Enabled',
+    dsn: config.dsn,
+    release: config.release,
+    environment: config.environment || 'production',
+  }
 }
 
 export function createSentryDataCollection() {

--- a/tests/sentry.test.ts
+++ b/tests/sentry.test.ts
@@ -1,25 +1,49 @@
 import { describe, expect, it } from 'vitest'
-import { dropExpectedNotFound, errorStatusCode, resolveServerSentryInitialization } from '../shared/sentry'
+import { dropExpectedNotFound, errorStatusCode, resolveSentryInitialization } from '../shared/sentry'
 
-describe('resolveServerSentryInitialization', () => {
+describe('resolveSentryInitialization', () => {
   it('keeps an unversioned local build out of production Sentry', () => {
-    expect(resolveServerSentryInitialization({
+    expect(resolveSentryInitialization({
       enabled: true,
       dsn: 'https://public@example.invalid/1',
       release: '',
+      environment: 'production',
     })).toEqual({ _tag: 'Disabled', reason: 'missing-release' })
   })
 
   it('enables a versioned production build', () => {
-    expect(resolveServerSentryInitialization({
+    expect(resolveSentryInitialization({
       enabled: true,
       dsn: 'https://public@example.invalid/1',
       release: 'abc123',
+      environment: 'production',
     })).toEqual({
       _tag: 'Enabled',
       dsn: 'https://public@example.invalid/1',
       release: 'abc123',
+      environment: 'production',
     })
+  })
+
+  it('carries the configured environment instead of assuming production', () => {
+    expect(resolveSentryInitialization({
+      enabled: true,
+      dsn: 'https://public@example.invalid/1',
+      release: 'abc123',
+      environment: 'staging',
+    })).toEqual({
+      _tag: 'Enabled',
+      dsn: 'https://public@example.invalid/1',
+      release: 'abc123',
+      environment: 'staging',
+    })
+  })
+
+  it('reports a disabled build and a build with no dsn separately', () => {
+    expect(resolveSentryInitialization({ enabled: false, dsn: 'https://public@example.invalid/1', release: 'abc123' }))
+      .toEqual({ _tag: 'Disabled', reason: 'disabled' })
+    expect(resolveSentryInitialization({ enabled: true, dsn: '', release: 'abc123' }))
+      .toEqual({ _tag: 'Disabled', reason: 'missing-dsn' })
   })
 })
 


### PR DESCRIPTION
### Description

Follow-up to #36, which closed this hole for the Nitro plugin and left it open for the browser SDK.

`sentry.client.config.ts` gated on `import.meta.dev`:

```ts
if (!import.meta.dev) {
  Sentry.init({ dsn: SENTRY_DSN, environment: 'production', ... })
}
```

Inside a local `wrangler dev` worker that is false, and the environment name was hardcoded, so a laptop running the production build reported browser errors into the production project. Same shape as the server event that prompted #36 (REQUEST-INDEXING-C arrived from `.wrangler/tmp/dev-*` tagged `environment:production`, with no release).

Both entry points now go through `resolveSentryInitialization`, renamed from `resolveServerSentryInitialization` since it is no longer server-only. It carries `environment` next to the DSN and release, so neither init call gets to name an environment of its own. The Sentry runtime config moves under `public` so the browser can read it (the module wraps `sentry.client.config.ts` in a Nuxt plugin, so `useRuntimeConfig()` works there).

Two things worth a look:

- Moving `runtimeConfig.sentry` to `runtimeConfig.public.sentry` changes the env override prefix to `NUXT_PUBLIC_SENTRY_*`. Nothing sets one today, and the DSN is already in the client bundle, so I do not think anything depends on it. Shout if a deploy does.
- I did not gate the `sentry:` module block itself on the release, so a local production build still bundles the SDK, just inert. Gating the module would drop it from the bundle entirely, but it also turns off source map upload, and I would rather not tangle the two in this PR.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).