### PR TITLE
chore(ci): skip the DX budget on docs-only changes

### DIFF
--- a/.github/workflows/nuxt-dx-budget.yml
+++ b/.github/workflows/nuxt-dx-budget.yml
@@ -1,10 +1,32 @@
 name: Nuxt DX budget
 
 on:
+  # A full production build, run only to measure one bundle. A docs-only change
+  # moves nothing this workflow measures, so it skips itself.
+  #
+  # `*.md` is single-star on purpose: it matches root markdown only. Site
+  # content lives in `apps/marketing/content/`, which Nuxt Content reads at build time, so a
+  # blanket `**.md` ignore would stop budgeting the markdown that counts.
+  #
+  # The list repeats because GitHub's workflow parser has no YAML anchors.
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - .editorconfig
+      - .gitignore
+      - '.idea/**'
+      - '.vscode/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - .editorconfig
+      - .gitignore
+      - '.idea/**'
+      - '.vscode/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
### Description

The DX budget builds the whole app just to measure the bundle, and it carries no
path filter, so a docs-only PR pays for a build that nothing in the diff moves.
harlan-zw/nuxtseo.com#303 closed the same gap there. Same filter, same reasoning,
applied here.

`*.md` stays single-star on purpose, so it matches root markdown only. Site content lives in `apps/marketing/content/`, which Nuxt Content reads at build time, and a blanket `**.md` ignore would quietly stop budgeting the markdown that does move the bundle.

### Additional context

The list is repeated across `push` and `pull_request` because GitHub's workflow
parser does not support YAML anchors.

`docs/**`, `.idea/**` and `.vscode/**` come straight from nuxtseo.com so the whole family reads the same. Nothing in this repo matches them today.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
