### PR TITLE
feat(dataforseo): meter public tool spend against a shared daily budget

### DIFF
--- a/apps/marketing/server/api/tools/bulk-check.post.ts
+++ b/apps/marketing/server/api/tools/bulk-check.post.ts
@@ -1,4 +1,10 @@
+import { checkUrlsIndexed, dataForSeoCallContext } from '~~/layers/core/server/app/services/dataforseo'
+import { checkDataForSeoBudget } from '~~/layers/core/server/app/services/dataforseo-spend'
+import { checkFreeToolRateLimit } from '#layers/pro-saas/server/utils/rate-limit'
+
 export default defineEventHandler(async (event) => {
+  await checkFreeToolRateLimit(event)
+
   const body = await readBody<{ urls?: string[], sitemapUrl?: string }>(event)
 
   let urls: string[] = []
@@ -43,7 +49,17 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  const results = await checkUrlsIndexed(urls)
+  const ctx = dataForSeoCallContext('bulk-check', event)
+  // Each URL is one SERP task, so the batch's cost scales with its size.
+  const budget = await checkDataForSeoBudget({ tool: ctx.tool!, endpoint: '/serp/google/organic/live/advanced', taskCount: urls.length }, ctx)
+  if (budget.blocked) {
+    throw createError({
+      statusCode: 429,
+      message: 'Bulk index checking is at capacity for today. Please try again tomorrow.',
+    })
+  }
+
+  const results = await checkUrlsIndexed(urls, ctx)
 
   const indexed = results.filter(r => r.indexed).length
   const notIndexed = results.filter(r => !r.indexed).length

--- a/apps/marketing/server/api/tools/check-index.post.ts
+++ b/apps/marketing/server/api/tools/check-index.post.ts
@@ -1,6 +1,11 @@
+import { checkUrlIndexed, dataForSeoCallContext } from '~~/layers/core/server/app/services/dataforseo'
+import { checkDataForSeoBudget } from '~~/layers/core/server/app/services/dataforseo-spend'
+import { checkFreeToolRateLimit } from '#layers/pro-saas/server/utils/rate-limit'
 import { runDataForSEORequest } from '../../../../../shared/dataforseo'
 
 export default defineEventHandler(async (event) => {
+  await checkFreeToolRateLimit(event)
+
   const body = await readBody<{ url: string }>(event)
 
   if (!body?.url?.trim())
@@ -11,15 +16,21 @@ export default defineEventHandler(async (event) => {
   // Basic URL validation
   let normalizedUrl = url
   if (!normalizedUrl.startsWith('http://') && !normalizedUrl.startsWith('https://'))
-    normalizedUrl = `https://${normalizedUrl}`
+    normalizedUrl = `https://${url}`
 
   if (!URL.canParse(normalizedUrl))
     throw createError({ statusCode: 400, message: 'Invalid URL format' })
 
-  // Rate limiting via simple in-memory check (per-request IP)
-  // In production, use Cloudflare KV or Durable Objects for proper rate limiting
+  const ctx = dataForSeoCallContext('check-index', event)
+  const budget = await checkDataForSeoBudget({ tool: ctx.tool!, endpoint: '/serp/google/organic/live/advanced', taskCount: 1 }, ctx)
+  if (budget.blocked) {
+    throw createError({
+      statusCode: 429,
+      message: 'Index checking is at capacity for today. Please try again tomorrow.',
+    })
+  }
 
-  const outcome = await runDataForSEORequest(() => checkUrlIndexed(normalizedUrl))
+  const outcome = await runDataForSEORequest(() => checkUrlIndexed(normalizedUrl, ctx))
 
   if (outcome._tag === 'Unavailable') {
     throw createError({

--- a/apps/marketing/server/api/tools/site-report.post.ts
+++ b/apps/marketing/server/api/tools/site-report.post.ts
@@ -1,4 +1,10 @@
+import { dataForSeoCallContext, getDomainOverview } from '~~/layers/core/server/app/services/dataforseo'
+import { checkDataForSeoBudget } from '~~/layers/core/server/app/services/dataforseo-spend'
+import { checkFreeToolRateLimit } from '#layers/pro-saas/server/utils/rate-limit'
+
 export default defineEventHandler(async (event) => {
+  await checkFreeToolRateLimit(event)
+
   const body = await readBody<{ domain: string }>(event)
 
   if (!body?.domain?.trim())
@@ -13,7 +19,17 @@ export default defineEventHandler(async (event) => {
   if (!domain || domain.includes(' '))
     throw createError({ statusCode: 400, message: 'Invalid domain' })
 
-  const overview = await getDomainOverview(domain)
+  const ctx = dataForSeoCallContext('site-report', event)
+  // One SERP task (depth 100) + one Labs task.
+  const budget = await checkDataForSeoBudget({ tool: ctx.tool!, endpoint: '/serp/google/organic/live/advanced', taskCount: 2 }, ctx)
+  if (budget.blocked) {
+    throw createError({
+      statusCode: 429,
+      message: 'Site reports are at capacity for today. Please try again tomorrow.',
+    })
+  }
+
+  const overview = await getDomainOverview(domain, ctx)
 
   // Calculate health score based on available data
   let healthScore = 50 // Base score

--- a/layers/core/server/app/services/dataforseo-spend.ts
+++ b/layers/core/server/app/services/dataforseo-spend.ts
@@ -1,0 +1,171 @@
+// Per-call cost accounting for the DataForSEO account shared with nuxtseo.com.
+//
+// Until 2026-08-23 the public tools spent credit with no record and no ceiling,
+// and the month's billing export could not be attributed to a caller. Every
+// outbound batch now writes one `dataforseo_requests` row carrying the
+// provider's OWN measured cost (micro-USD), and a shared daily budget closes
+// the tools once it is spent — the same contract nuxtseo.com's free tools
+// adopted the same week.
+//
+// Dependencies are explicit: budget and storage arrive as a `DataForSeoSpendEnv`
+// so the decision core stays pure and testable; the route seam passes the nitro
+// defaults via `dataForSeoSpendEnv(event)`.
+
+import type { H3Event } from 'h3'
+import { getHeader } from 'h3'
+
+const USD_MICROS = 1_000_000
+
+/**
+ * The counter store surface the budget needs — the shape nitro's `cache`
+ * storage already provides. Structural (not `unstorage.Storage`) so this
+ * module adds no dependency and tests can hand-roll a Map.
+ */
+export interface DataForSeoSpendStorage {
+  getItem: (key: string) => Promise<unknown>
+  setItem: (key: string, value: number, opts?: { ttl: number }) => Promise<void>
+}
+
+/**
+ * List price per task, micro-USD, for the live endpoints the tools use. Used
+ * only by the PRE-call gate to predict a batch's cost; the ledger and the
+ * budget counter record the provider's measured cost afterwards.
+ *   - SERP organic live advanced: $0.0015/task (depth ≤ 100)
+ *   - Labs domain_rank_overview live: $0.0021/task
+ */
+export const TASK_COST_MICROS: ReadonlyMap<string, number> = new Map([
+  ['/serp/google/organic/live/advanced', 1500],
+  ['/dataforseo_labs/google/domain_rank_overview/live', 2100],
+])
+
+/** Daily ceiling for all DataForSEO tool spend combined, USD. Default $5. */
+export const DEFAULT_DAILY_BUDGET_USD = 5
+
+export interface DataForSeoSpendEnv {
+  /** Budget ceiling in micro-USD for the UTC day. */
+  budgetMicros: number
+  /** The counter store. In production the `cache` KV namespace. */
+  storage: DataForSeoSpendStorage
+}
+
+/**
+ * Resolve the production env: `dataforseo.dailyBudgetUsd` runtime config
+ * (NUXT_DATAFORSEO_DAILY_BUDGET_USD) and the `cache` storage namespace.
+ */
+export function dataForSeoSpendEnv(): DataForSeoSpendEnv {
+  const config = useRuntimeConfig().dataforseo as { dailyBudgetUsd?: string } | undefined
+  const n = Number(config?.dailyBudgetUsd)
+  const budgetUsd = Number.isFinite(n) && n > 0 ? n : DEFAULT_DAILY_BUDGET_USD
+  return { budgetMicros: Math.round(budgetUsd * USD_MICROS), storage: useStorage('cache') }
+}
+
+function dayBucket(now: Date): string {
+  return `dataforseo:budget:${now.toISOString().slice(0, 10)}`
+}
+
+function secondsUntilDayEnd(now: Date): number {
+  const end = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1)
+  return Math.ceil((end - now.getTime()) / 1000) + 60
+}
+
+export interface DataForSeoSpendQuery {
+  /** Caller-facing tool name for attribution, e.g. 'check-index'. */
+  tool: string
+  /** Provider endpoint path. */
+  endpoint: string
+  /** Tasks in the batch. Cost is metered per task; the ledger row records the count. */
+  taskCount: number
+}
+
+export interface DataForSeoSpendVerdict {
+  /** True when the daily budget is exhausted and the call must not be made. */
+  blocked: boolean
+  /** Micro-USD spent today so far, all tools combined. */
+  spentMicros: number
+  /** Micro-USD the caller may still spend today. */
+  remainingMicros: number
+}
+
+/**
+ * Read today's shared spend and decide whether one more call fits.
+ *
+ * A storage read that fails opens the gate instead of closing it: a missing
+ * counter must read as "nothing spent", never as "budget gone" — the tools
+ * being up is worth more than the cents a broken KV read would save.
+ */
+export async function checkDataForSeoBudget(
+  query: DataForSeoSpendQuery,
+  env: DataForSeoSpendEnv,
+  now = new Date(),
+): Promise<DataForSeoSpendVerdict> {
+  const spent = await env.storage.getItem(dayBucket(now)).catch(() => null) as number | null ?? 0
+  const perCall = query.taskCount * (TASK_COST_MICROS.get(query.endpoint) ?? 0)
+  return {
+    blocked: spent + perCall > env.budgetMicros,
+    spentMicros: spent,
+    remainingMicros: Math.max(0, env.budgetMicros - spent),
+  }
+}
+
+/**
+ * Record one completed batch against the ledger and the daily budget.
+ *
+ * `costUsdMicros` is the provider's measured sum for the tasks it actually
+ * served, read from the response envelope; null when the batch failed before a
+ * body (HTTP error), where DataForSEO charges nothing. Best-effort: a ledger or
+ * KV failure logs and never breaks the tool response, because the budget gate
+ * already ran before the call.
+ *
+ * `env` carries the spend environment plus the optional request event (for the
+ * caller-IP hash on the ledger row) — the shape every service call context is.
+ */
+export async function recordDataForSeoSpend(
+  query: DataForSeoSpendQuery,
+  outcome: { httpStatus: number, costUsdMicros: number | null },
+  env: DataForSeoSpendEnv & { event?: H3Event },
+  now = new Date(),
+): Promise<void> {
+  const event = env.event
+  const ipHash = event
+    ? await hashCallerIp(event).catch(() => null)
+    : null
+
+  const bucket = dayBucket(now)
+  // Lazy: keeps this module free of a drizzle import at load time (tools that
+  // only gate don't pay it), and resolves the binding from the event when one
+  // is in scope.
+  const { useDrizzle, tables } = await import('../../utils/drizzle')
+  const results = await Promise.allSettled([
+    useDrizzle(event).insert(tables.dataforseoRequests).values({
+      tool: query.tool,
+      endpoint: query.endpoint,
+      taskCount: query.taskCount,
+      status: outcome.httpStatus >= 200 && outcome.httpStatus < 300 ? 'ok' : 'http_error',
+      httpStatus: outcome.httpStatus,
+      costUsdMicros: outcome.costUsdMicros,
+      ipHash,
+      createdAt: now,
+    }),
+    outcome.costUsdMicros !== null
+      ? env.storage.getItem(bucket)
+          .catch(() => null)
+          .then((spent: unknown) =>
+            env.storage.setItem(bucket, (typeof spent === 'number' ? spent : 0) + outcome.costUsdMicros!, { ttl: secondsUntilDayEnd(now) }))
+      : Promise.resolve(),
+  ])
+  // Genuinely ignorable best-effort: the gate already ran pre-call, so a failed
+  // record only means the ceiling closes a few calls late.
+  for (const r of results) {
+    if (r.status === 'rejected')
+      console.warn('[dataforseo-spend] record failed', r.reason)
+  }
+}
+
+async function hashCallerIp(event: H3Event): Promise<string | null> {
+  const ip = getHeader(event, 'cf-connecting-ip')
+    || getHeader(event, 'x-forwarded-for')?.split(',')[0]?.trim()
+  if (!ip)
+    return null
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(ip))
+  return `ip:${[...new Uint8Array(digest)].slice(0, 8).map(b => b.toString(16).padStart(2, '0')).join('')}`
+}

--- a/layers/core/server/app/services/dataforseo.ts
+++ b/layers/core/server/app/services/dataforseo.ts
@@ -1,4 +1,23 @@
+import type { H3Event } from 'h3'
+import type { DataForSeoSpendEnv } from './dataforseo-spend'
 import { DATAFORSEO_RETRY_OPTIONS } from '../../../../../shared/dataforseo'
+import { dataForSeoSpendEnv, recordDataForSeoSpend } from './dataforseo-spend'
+
+export interface DataForSeoCallContext extends DataForSeoSpendEnv {
+  /** Tool name for spend attribution, e.g. 'check-index'. Omitted = unmetered. */
+  tool?: string
+  /** Request event, for the caller-IP hash on the ledger row. */
+  event?: H3Event
+}
+
+/**
+ * Build the per-call context the route seam hands to every service function:
+ * the spend env plus attribution. `tool` omitted means the call is internal and
+ * still metered through the shared budget (env only, no ledger attribution).
+ */
+export function dataForSeoCallContext(tool: string, event?: H3Event): DataForSeoCallContext {
+  return { tool, event, ...dataForSeoSpendEnv() }
+}
 
 interface DataForSEOCredentials {
   login: string
@@ -19,7 +38,9 @@ interface SerpTaskResult {
 }
 
 interface DataForSeoResponse<T> {
-  tasks?: Array<{ result?: T[] }>
+  status_code?: number
+  cost?: number
+  tasks?: Array<{ result?: T[], cost?: number }>
 }
 
 interface DomainRankResult {
@@ -57,19 +78,51 @@ function getAuthHeader(): string {
   return `Basic ${btoa(`${login}:${password}`)}`
 }
 
-async function dataforseoFetch<T>(endpoint: string, body: Record<string, unknown>[]): Promise<T> {
-  return $fetch<T>(`https://api.dataforseo.com/v3${endpoint}`, {
-    ...DATAFORSEO_RETRY_OPTIONS,
-    method: 'POST',
-    headers: {
-      'Authorization': getAuthHeader(),
-      'Content-Type': 'application/json',
-    },
-    body,
-  })
+/**
+ * One POST to a live endpoint: transport + spend record. Every call to the
+ * shared account goes through here, so every batch lands in the
+ * `dataforseo_requests` ledger with the provider's measured cost. The meter is
+ * best-effort and never fails the call: the budget GATE runs at the route seam
+ * before the provider is reached.
+ */
+async function dataforseoFetch<T>(endpoint: string, body: Record<string, unknown>[], ctx?: DataForSeoCallContext): Promise<T> {
+  try {
+    const data = await $fetch<DataForSeoResponse<T>>(`https://api.dataforseo.com/v3${endpoint}`, {
+      ...DATAFORSEO_RETRY_OPTIONS,
+      method: 'POST',
+      headers: {
+        'Authorization': getAuthHeader(),
+        'Content-Type': 'application/json',
+      },
+      body,
+    })
+    if (ctx?.tool) {
+      // `cost` is USD for the tasks this response actually served.
+      void recordDataForSeoSpend(
+        { tool: ctx.tool, endpoint, taskCount: body.length },
+        { httpStatus: 200, costUsdMicros: typeof data.cost === 'number' ? Math.round(data.cost * 1e6) : null },
+        ctx,
+      )
+    }
+    return data as T
+  }
+  catch (err: any) {
+    const httpStatus = typeof err?.statusCode === 'number' ? err.statusCode : typeof err?.response?.status === 'number' ? err.response.status : 0
+    if (ctx?.tool) {
+      // Failed transport: no body, provider charges nothing, but the attempt
+      // is still evidence — a 402 storm here is how the account running dry
+      // was first noticed.
+      void recordDataForSeoSpend(
+        { tool: ctx.tool, endpoint, taskCount: body.length },
+        { httpStatus, costUsdMicros: null },
+        ctx,
+      )
+    }
+    throw err
+  }
 }
 
-export async function checkUrlIndexed(url: string): Promise<IndexCheckResult> {
+export async function checkUrlIndexed(url: string, ctx?: DataForSeoCallContext): Promise<IndexCheckResult> {
   const data = await dataforseoFetch<DataForSeoResponse<SerpTaskResult>>('/serp/google/organic/live/advanced', [
     {
       keyword: `site:${url}`,
@@ -77,7 +130,7 @@ export async function checkUrlIndexed(url: string): Promise<IndexCheckResult> {
       language_code: 'en',
       depth: 10,
     },
-  ])
+  ], ctx)
 
   const task = data?.tasks?.[0]
   const result = task?.result?.[0]
@@ -98,7 +151,7 @@ export async function checkUrlIndexed(url: string): Promise<IndexCheckResult> {
   }
 }
 
-export async function checkUrlsIndexed(urls: string[]): Promise<IndexCheckResult[]> {
+export async function checkUrlsIndexed(urls: string[], ctx?: DataForSeoCallContext): Promise<IndexCheckResult[]> {
   // DataForSEO allows batching — send multiple tasks in one request
   const tasks = urls.map((url, i) => ({
     keyword: `site:${url}`,
@@ -114,7 +167,7 @@ export async function checkUrlsIndexed(urls: string[]): Promise<IndexCheckResult
 
   for (let i = 0; i < tasks.length; i += batchSize) {
     const batch = tasks.slice(i, i + batchSize)
-    const data = await dataforseoFetch<DataForSeoResponse<SerpTaskResult>>('/serp/google/organic/live/advanced', batch)
+    const data = await dataforseoFetch<DataForSeoResponse<SerpTaskResult>>('/serp/google/organic/live/advanced', batch, ctx)
 
     for (let j = 0; j < batch.length; j++) {
       const task = data?.tasks?.[j]
@@ -141,7 +194,7 @@ export async function checkUrlsIndexed(urls: string[]): Promise<IndexCheckResult
   return results
 }
 
-export async function getDomainOverview(domain: string): Promise<DomainOverviewResult> {
+export async function getDomainOverview(domain: string, ctx?: DataForSeoCallContext): Promise<DomainOverviewResult> {
   // Get estimated indexed pages via site: query
   const siteData = await dataforseoFetch<DataForSeoResponse<SerpTaskResult>>('/serp/google/organic/live/advanced', [
     {
@@ -150,7 +203,7 @@ export async function getDomainOverview(domain: string): Promise<DomainOverviewR
       language_code: 'en',
       depth: 100,
     },
-  ])
+  ], ctx)
 
   const siteResult = siteData?.tasks?.[0]?.result?.[0]
   const estimatedIndexedPages = siteResult?.total || 0
@@ -174,7 +227,7 @@ export async function getDomainOverview(domain: string): Promise<DomainOverviewR
         location_code: 2840,
         language_code: 'en',
       },
-    ])
+    ], ctx)
 
     const domainResult = domainData?.tasks?.[0]?.result?.[0]?.items?.[0]
     if (domainResult) {

--- a/layers/core/server/db/migrations/0012_dataforseo_requests.sql
+++ b/layers/core/server/db/migrations/0012_dataforseo_requests.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `dataforseo_requests` (
+	`dataforseo_request_id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`tool` text NOT NULL,
+	`endpoint` text NOT NULL,
+	`task_count` integer DEFAULT 1 NOT NULL,
+	`status` text NOT NULL,
+	`http_status` integer,
+	`cost_usd_micros` integer,
+	`ip_hash` text,
+	`created_at` integer
+);
+--> statement-breakpoint
+CREATE INDEX `dataforseo_requests_created_idx` ON `dataforseo_requests` (`created_at`);--> statement-breakpoint
+CREATE INDEX `dataforseo_requests_tool_created_idx` ON `dataforseo_requests` (`tool`,`created_at`);

--- a/layers/core/server/db/migrations/meta/0012_snapshot.json
+++ b/layers/core/server/db/migrations/meta/0012_snapshot.json
@@ -1,0 +1,4324 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "57f3ce63-84b6-445e-ba5b-3ad6cfd03eb0",
+  "prevId": "892ef904-ceb9-47ed-97cf-3d680699d30e",
+  "tables": {
+    "admin_events": {
+      "name": "admin_events",
+      "columns": {
+        "admin_event_id": {
+          "name": "admin_event_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "admin_events_kind_created_idx": {
+          "name": "admin_events_kind_created_idx",
+          "columns": [
+            "kind",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "admin_events_actor_user_id_users_user_id_fk": {
+          "name": "admin_events_actor_user_id_users_user_id_fk",
+          "tableFrom": "admin_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pro_api_usage_events": {
+      "name": "pro_api_usage_events",
+      "columns": {
+        "api_usage_event_id": {
+          "name": "api_usage_event_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_api_token_id": {
+          "name": "team_api_token_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'success'"
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time": {
+          "name": "response_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client": {
+          "name": "client",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pro_api_usage_events_team_created_idx": {
+          "name": "pro_api_usage_events_team_created_idx",
+          "columns": [
+            "team_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pro_api_usage_events_token_created_idx": {
+          "name": "pro_api_usage_events_token_created_idx",
+          "columns": [
+            "team_api_token_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pro_api_usage_events_team_source_created_idx": {
+          "name": "pro_api_usage_events_team_source_created_idx",
+          "columns": [
+            "team_id",
+            "source",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pro_api_usage_events_team_id_teams_team_id_fk": {
+          "name": "pro_api_usage_events_team_id_teams_team_id_fk",
+          "tableFrom": "pro_api_usage_events",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pro_api_usage_events_team_api_token_id_team_api_tokens_team_api_token_id_fk": {
+          "name": "pro_api_usage_events_team_api_token_id_team_api_tokens_team_api_token_id_fk",
+          "tableFrom": "pro_api_usage_events",
+          "tableTo": "team_api_tokens",
+          "columnsFrom": [
+            "team_api_token_id"
+          ],
+          "columnsTo": [
+            "team_api_token_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pro_api_usage_events_user_id_users_user_id_fk": {
+          "name": "pro_api_usage_events_user_id_users_user_id_fk",
+          "tableFrom": "pro_api_usage_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "dataforseo_requests": {
+      "name": "dataforseo_requests",
+      "columns": {
+        "dataforseo_request_id": {
+          "name": "dataforseo_request_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tool": {
+          "name": "tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_count": {
+          "name": "task_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd_micros": {
+          "name": "cost_usd_micros",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "dataforseo_requests_created_idx": {
+          "name": "dataforseo_requests_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "dataforseo_requests_tool_created_idx": {
+          "name": "dataforseo_requests_tool_created_idx",
+          "columns": [
+            "tool",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "failed_jobs": {
+      "name": "failed_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "queue": {
+          "name": "queue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exception": {
+          "name": "exception",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback": {
+      "name": "feedback",
+      "columns": {
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_user_id_users_user_id_fk": {
+          "name": "feedback_user_id_users_user_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "google_accounts": {
+      "name": "google_accounts",
+      "columns": {
+        "google_account_id": {
+          "name": "google_account_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_info": {
+          "name": "token_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "google_oauth_client_id": {
+          "name": "google_oauth_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "google_accounts_user_id_users_user_id_fk": {
+          "name": "google_accounts_user_id_users_user_id_fk",
+          "tableFrom": "google_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "google_accounts_google_oauth_client_id_google_oauth_clients_google_oauth_client_id_fk": {
+          "name": "google_accounts_google_oauth_client_id_google_oauth_clients_google_oauth_client_id_fk",
+          "tableFrom": "google_accounts",
+          "tableTo": "google_oauth_clients",
+          "columnsFrom": [
+            "google_oauth_client_id"
+          ],
+          "columnsTo": [
+            "google_oauth_client_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "google_oauth_clients": {
+      "name": "google_oauth_clients",
+      "columns": {
+        "google_oauth_client_id": {
+          "name": "google_oauth_client_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reserved": {
+          "name": "reserved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "google_oauth_clients_client_id_unique": {
+          "name": "google_oauth_clients_client_id_unique",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexing_investigations": {
+      "name": "indexing_investigations",
+      "columns": {
+        "indexing_investigation_id": {
+          "name": "indexing_investigation_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'investigated'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "investigated_at": {
+          "name": "investigated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "indexing_investigations_site_idx": {
+          "name": "indexing_investigations_site_idx",
+          "columns": [
+            "site_id"
+          ],
+          "isUnique": false
+        },
+        "indexing_investigations_site_url_issue_unique": {
+          "name": "indexing_investigations_site_url_issue_unique",
+          "columns": [
+            "site_id",
+            "url",
+            "issue_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "indexing_investigations_site_id_sites_site_id_fk": {
+          "name": "indexing_investigations_site_id_sites_site_id_fk",
+          "tableFrom": "indexing_investigations",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexing_jobs": {
+      "name": "indexing_jobs",
+      "columns": {
+        "indexing_job_id": {
+          "name": "indexing_job_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "indexing_jobs_site_state_idx": {
+          "name": "indexing_jobs_site_state_idx",
+          "columns": [
+            "site_id",
+            "state"
+          ],
+          "isUnique": false
+        },
+        "indexing_jobs_site_path_transport_unique": {
+          "name": "indexing_jobs_site_path_transport_unique",
+          "columns": [
+            "site_id",
+            "path",
+            "transport"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "indexing_jobs_site_id_sites_site_id_fk": {
+          "name": "indexing_jobs_site_id_sites_site_id_fk",
+          "tableFrom": "indexing_jobs",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "job_batches": {
+      "name": "job_batches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_batch_id": {
+          "name": "parent_batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_jobs": {
+          "name": "total_jobs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pending_jobs": {
+          "name": "pending_jobs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "failed_jobs": {
+          "name": "failed_jobs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "on_finish": {
+          "name": "on_finish",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allow_failures": {
+          "name": "allow_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "jobs": {
+      "name": "jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "queue": {
+          "name": "queue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "queue_idx": {
+          "name": "queue_idx",
+          "columns": [
+            "queue"
+          ],
+          "isUnique": false
+        },
+        "batch_idx": {
+          "name": "batch_idx",
+          "columns": [
+            "batch_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "keywords": {
+      "name": "keywords",
+      "columns": {
+        "keyword_id": {
+          "name": "keyword_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_index": {
+          "name": "competition_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "competition": {
+          "name": "competition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monthly_search_volumes": {
+          "name": "monthly_search_volumes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avg_monthly_searches": {
+          "name": "avg_monthly_searches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_month_search_volume": {
+          "name": "current_month_search_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "average_cpc_micros": {
+          "name": "average_cpc_micros",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced": {
+          "name": "last_synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "keywords_keyword_unique": {
+          "name": "keywords_keyword_unique",
+          "columns": [
+            "keyword"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pro_mcp_usage": {
+      "name": "pro_mcp_usage",
+      "columns": {
+        "mcp_usage_id": {
+          "name": "mcp_usage_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_api_token_id": {
+          "name": "team_api_token_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client": {
+          "name": "client",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'success'"
+        },
+        "response_time": {
+          "name": "response_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pro_mcp_usage_team_api_token_idx": {
+          "name": "pro_mcp_usage_team_api_token_idx",
+          "columns": [
+            "team_api_token_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pro_mcp_usage_user_id_users_user_id_fk": {
+          "name": "pro_mcp_usage_user_id_users_user_id_fk",
+          "tableFrom": "pro_mcp_usage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pro_mcp_usage_team_id_teams_team_id_fk": {
+          "name": "pro_mcp_usage_team_id_teams_team_id_fk",
+          "tableFrom": "pro_mcp_usage",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pro_mcp_usage_team_api_token_id_team_api_tokens_team_api_token_id_fk": {
+          "name": "pro_mcp_usage_team_api_token_id_team_api_tokens_team_api_token_id_fk",
+          "tableFrom": "pro_mcp_usage",
+          "tableTo": "team_api_tokens",
+          "columnsFrom": [
+            "team_api_token_id"
+          ],
+          "columnsTo": [
+            "team_api_token_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_user_id_fk": {
+          "name": "notifications_user_id_users_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pro_events": {
+      "name": "pro_events",
+      "columns": {
+        "pro_event_id": {
+          "name": "pro_event_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pro_events_user_type_idx": {
+          "name": "pro_events_user_type_idx",
+          "columns": [
+            "user_id",
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pro_events_user_id_users_user_id_fk": {
+          "name": "pro_events_user_id_users_user_id_fk",
+          "tableFrom": "pro_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "related_keywords": {
+      "name": "related_keywords",
+      "columns": {
+        "keyword_id": {
+          "name": "keyword_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "related_keyword_id": {
+          "name": "related_keyword_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "related_keywords_keyword_id_related_keyword_id_site_id_unique": {
+          "name": "related_keywords_keyword_id_related_keyword_id_site_id_unique",
+          "columns": [
+            "keyword_id",
+            "related_keyword_id",
+            "site_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "related_keywords_keyword_id_keywords_keyword_id_fk": {
+          "name": "related_keywords_keyword_id_keywords_keyword_id_fk",
+          "tableFrom": "related_keywords",
+          "tableTo": "keywords",
+          "columnsFrom": [
+            "keyword_id"
+          ],
+          "columnsTo": [
+            "keyword_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "related_keywords_related_keyword_id_keywords_keyword_id_fk": {
+          "name": "related_keywords_related_keyword_id_keywords_keyword_id_fk",
+          "tableFrom": "related_keywords",
+          "tableTo": "keywords",
+          "columnsFrom": [
+            "related_keyword_id"
+          ],
+          "columnsTo": [
+            "keyword_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "related_keywords_site_id_sites_site_id_fk": {
+          "name": "related_keywords_site_id_sites_site_id_fk",
+          "tableFrom": "related_keywords",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runtime_errors": {
+      "name": "runtime_errors",
+      "columns": {
+        "runtime_error_id": {
+          "name": "runtime_error_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ctx": {
+          "name": "ctx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "runtime_errors_name_created_idx": {
+          "name": "runtime_errors_name_created_idx",
+          "columns": [
+            "name",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "runtime_errors_user_created_idx": {
+          "name": "runtime_errors_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "runtime_errors_level_created_idx": {
+          "name": "runtime_errors_level_created_idx",
+          "columns": [
+            "level",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_activity": {
+          "name": "last_activity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_user_id_ip_address_user_agent_unique": {
+          "name": "sessions_user_id_ip_address_user_agent_unique",
+          "columns": [
+            "user_id",
+            "ip_address",
+            "user_agent"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_user_id_fk": {
+          "name": "sessions_user_id_users_user_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_date_analytics": {
+      "name": "site_date_analytics",
+      "columns": {
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "impressions": {
+          "name": "impressions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "ctr": {
+          "name": "ctr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "mobile_origin_cls_75": {
+          "name": "mobile_origin_cls_75",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mobile_origin_ttfb_75": {
+          "name": "mobile_origin_ttfb_75",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mobile_origin_fcp_75": {
+          "name": "mobile_origin_fcp_75",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mobile_origin_lcp_75": {
+          "name": "mobile_origin_lcp_75",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mobile_origin_inp_75": {
+          "name": "mobile_origin_inp_75",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "desktop_origin_cls_75": {
+          "name": "desktop_origin_cls_75",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "desktop_origin_ttfb_75": {
+          "name": "desktop_origin_ttfb_75",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "desktop_origin_fcp_75": {
+          "name": "desktop_origin_fcp_75",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "desktop_origin_lcp_75": {
+          "name": "desktop_origin_lcp_75",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "desktop_origin_inp_75": {
+          "name": "desktop_origin_inp_75",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mobile_clicks": {
+          "name": "mobile_clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mobile_impressions": {
+          "name": "mobile_impressions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mobile_ctr": {
+          "name": "mobile_ctr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mobile_position": {
+          "name": "mobile_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "desktop_clicks": {
+          "name": "desktop_clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "desktop_impressions": {
+          "name": "desktop_impressions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "desktop_ctr": {
+          "name": "desktop_ctr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "desktop_position": {
+          "name": "desktop_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tablet_clicks": {
+          "name": "tablet_clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tablet_impressions": {
+          "name": "tablet_impressions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tablet_ctr": {
+          "name": "tablet_ctr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tablet_position": {
+          "name": "tablet_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_synced": {
+          "name": "is_synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "indexed_pages_count": {
+          "name": "indexed_pages_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_pages_count": {
+          "name": "total_pages_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "site_date_analytics_site_id_date_unique": {
+          "name": "site_date_analytics_site_id_date_unique",
+          "columns": [
+            "site_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "site_date_analytics_site_id_sites_site_id_fk": {
+          "name": "site_date_analytics_site_id_sites_site_id_fk",
+          "tableFrom": "site_date_analytics",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_date_country_analytics": {
+      "name": "site_date_country_analytics",
+      "columns": {
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "impressions": {
+          "name": "impressions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "ctr": {
+          "name": "ctr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "site_date_country_analytics_site_id_date_country_unique": {
+          "name": "site_date_country_analytics_site_id_date_country_unique",
+          "columns": [
+            "site_id",
+            "date",
+            "country"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "site_date_country_analytics_site_id_sites_site_id_fk": {
+          "name": "site_date_country_analytics_site_id_sites_site_id_fk",
+          "tableFrom": "site_date_country_analytics",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_groups": {
+      "name": "site_groups",
+      "columns": {
+        "site_group_id": {
+          "name": "site_group_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "site_groups_team_id_teams_team_id_fk": {
+          "name": "site_groups_team_id_teams_team_id_fk",
+          "tableFrom": "site_groups",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_keyword_date_analytics": {
+      "name": "site_keyword_date_analytics",
+      "columns": {
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "impressions": {
+          "name": "impressions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "ctr": {
+          "name": "ctr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "site_keyword_date_analytics_site_id_date_keyword_unique": {
+          "name": "site_keyword_date_analytics_site_id_date_keyword_unique",
+          "columns": [
+            "site_id",
+            "date",
+            "keyword"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "site_keyword_date_analytics_site_id_sites_site_id_fk": {
+          "name": "site_keyword_date_analytics_site_id_sites_site_id_fk",
+          "tableFrom": "site_keyword_date_analytics",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_keyword_date_path_analytics": {
+      "name": "site_keyword_date_path_analytics",
+      "columns": {
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device": {
+          "name": "device",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "impressions": {
+          "name": "impressions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "ctr": {
+          "name": "ctr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "site_keyword_date_path_analytics_site_id_date_keyword_path_country_device_unique": {
+          "name": "site_keyword_date_path_analytics_site_id_date_keyword_path_country_device_unique",
+          "columns": [
+            "site_id",
+            "date",
+            "keyword",
+            "path",
+            "country",
+            "device"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "site_keyword_date_path_analytics_site_id_sites_site_id_fk": {
+          "name": "site_keyword_date_path_analytics_site_id_sites_site_id_fk",
+          "tableFrom": "site_keyword_date_path_analytics",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_path_date_analytics": {
+      "name": "site_path_date_analytics",
+      "columns": {
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "impressions": {
+          "name": "impressions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "ctr": {
+          "name": "ctr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "site_path_date_analytics_site_id_date_path_unique": {
+          "name": "site_path_date_analytics_site_id_date_path_unique",
+          "columns": [
+            "site_id",
+            "date",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "site_path_date_analytics_site_id_sites_site_id_fk": {
+          "name": "site_path_date_analytics_site_id_sites_site_id_fk",
+          "tableFrom": "site_path_date_analytics",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_paths": {
+      "name": "site_paths",
+      "columns": {
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen_indexed": {
+          "name": "first_seen_indexed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_indexed": {
+          "name": "is_indexed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "indexing_verdict": {
+          "name": "indexing_verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inspection_payload": {
+          "name": "inspection_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_inspected": {
+          "name": "last_inspected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "path_site_url_idx": {
+          "name": "path_site_url_idx",
+          "columns": [
+            "path"
+          ],
+          "isUnique": false
+        },
+        "site_paths_site_id_path_unique": {
+          "name": "site_paths_site_id_path_unique",
+          "columns": [
+            "site_id",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "site_paths_site_id_sites_site_id_fk": {
+          "name": "site_paths_site_id_sites_site_id_fk",
+          "tableFrom": "site_paths",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sites": {
+      "name": "sites",
+      "columns": {
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property": {
+          "name": "property",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sitemaps": {
+          "name": "sitemaps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced": {
+          "name": "last_synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_synced": {
+          "name": "is_synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gscdump_site_id": {
+          "name": "gscdump_site_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gscdump_site_url": {
+          "name": "gscdump_site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gscdump_sync_status": {
+          "name": "gscdump_sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "sites_domain_unique": {
+          "name": "sites_domain_unique",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": true
+        },
+        "sites_public_id_unique": {
+          "name": "sites_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sites_parent_id_sites_site_id_fk": {
+          "name": "sites_parent_id_sites_site_id_fk",
+          "tableFrom": "sites",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sites_owner_id_users_user_id_fk": {
+          "name": "sites_owner_id_users_user_id_fk",
+          "tableFrom": "sites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_api_tokens": {
+      "name": "team_api_tokens",
+      "columns": {
+        "team_api_token_id": {
+          "name": "team_api_token_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last4": {
+          "name": "last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_api_tokens_team_idx": {
+          "name": "team_api_tokens_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "team_api_tokens_token_hash_unique": {
+          "name": "team_api_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_api_tokens_team_id_teams_team_id_fk": {
+          "name": "team_api_tokens_team_id_teams_team_id_fk",
+          "tableFrom": "team_api_tokens",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_api_tokens_user_id_users_user_id_fk": {
+          "name": "team_api_tokens_user_id_users_user_id_fk",
+          "tableFrom": "team_api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_audit_events": {
+      "name": "team_audit_events",
+      "columns": {
+        "team_audit_event_id": {
+          "name": "team_audit_event_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_audit_events_team_created_idx": {
+          "name": "team_audit_events_team_created_idx",
+          "columns": [
+            "team_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "team_audit_events_team_id_teams_team_id_fk": {
+          "name": "team_audit_events_team_id_teams_team_id_fk",
+          "tableFrom": "team_audit_events",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_audit_events_actor_user_id_users_user_id_fk": {
+          "name": "team_audit_events_actor_user_id_users_user_id_fk",
+          "tableFrom": "team_audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_gsc_credentials": {
+      "name": "team_gsc_credentials",
+      "columns": {
+        "team_gsc_credential_id": {
+          "name": "team_gsc_credential_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gscdump_user_id": {
+          "name": "gscdump_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_gsc_credentials_team_user_unique": {
+          "name": "team_gsc_credentials_team_user_unique",
+          "columns": [
+            "team_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_gsc_credentials_team_id_teams_team_id_fk": {
+          "name": "team_gsc_credentials_team_id_teams_team_id_fk",
+          "tableFrom": "team_gsc_credentials",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_gsc_credentials_user_id_users_user_id_fk": {
+          "name": "team_gsc_credentials_user_id_users_user_id_fk",
+          "tableFrom": "team_gsc_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_invitations": {
+      "name": "team_invitations",
+      "columns": {
+        "team_invitation_id": {
+          "name": "team_invitation_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_by_id": {
+          "name": "invited_by_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_invitations_token_unique": {
+          "name": "team_invitations_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "team_invitations_team_email_unique": {
+          "name": "team_invitations_team_email_unique",
+          "columns": [
+            "team_id",
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_invitations_team_id_teams_team_id_fk": {
+          "name": "team_invitations_team_id_teams_team_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_invitations_invited_by_id_users_user_id_fk": {
+          "name": "team_invitations_invited_by_id_users_user_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_memberships": {
+      "name": "team_memberships",
+      "columns": {
+        "team_membership_id": {
+          "name": "team_membership_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_visit_dismissed_at": {
+          "name": "first_visit_dismissed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_memberships_team_user_unique": {
+          "name": "team_memberships_team_user_unique",
+          "columns": [
+            "team_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_memberships_team_id_teams_team_id_fk": {
+          "name": "team_memberships_team_id_teams_team_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_memberships_user_id_users_user_id_fk": {
+          "name": "team_memberships_user_id_users_user_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_sites": {
+      "name": "team_sites",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "google_account_id": {
+          "name": "google_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "google_account_id_idx": {
+          "name": "google_account_id_idx",
+          "columns": [
+            "google_account_id"
+          ],
+          "isUnique": false
+        },
+        "team_sites_team_id_site_id_unique": {
+          "name": "team_sites_team_id_site_id_unique",
+          "columns": [
+            "team_id",
+            "site_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_sites_team_id_teams_team_id_fk": {
+          "name": "team_sites_team_id_teams_team_id_fk",
+          "tableFrom": "team_sites",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_sites_site_id_sites_site_id_fk": {
+          "name": "team_sites_site_id_sites_site_id_fk",
+          "tableFrom": "team_sites",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_sites_google_account_id_google_accounts_google_account_id_fk": {
+          "name": "team_sites_google_account_id_google_accounts_google_account_id_fk",
+          "tableFrom": "team_sites",
+          "tableTo": "google_accounts",
+          "columnsFrom": [
+            "google_account_id"
+          ],
+          "columnsTo": [
+            "google_account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_user": {
+      "name": "team_user",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "team_user_team_id_user_id_unique": {
+          "name": "team_user_team_id_user_id_unique",
+          "columns": [
+            "team_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_user_team_id_teams_team_id_fk": {
+          "name": "team_user_team_id_teams_team_id_fk",
+          "tableFrom": "team_user",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_user_user_id_users_user_id_fk": {
+          "name": "team_user_user_id_users_user_id_fk",
+          "tableFrom": "team_user",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_user_invite": {
+      "name": "team_user_invite",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "personal_team": {
+          "name": "personal_team",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backups_enabled": {
+          "name": "backups_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "onboarded_step": {
+          "name": "onboarded_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gscdump_team_id": {
+          "name": "gscdump_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_owner_id_users_user_id_fk": {
+          "name": "teams_owner_id_users_user_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "telemetry_events": {
+      "name": "telemetry_events",
+      "columns": {
+        "telemetry_event_id": {
+          "name": "telemetry_event_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_hash": {
+          "name": "project_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modules": {
+          "name": "modules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "module_versions": {
+          "name": "module_versions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nuxt_version": {
+          "name": "nuxt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "node_version": {
+          "name": "node_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_manager": {
+          "name": "package_manager",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ci": {
+          "name": "ci",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telemetry_events_user_id_users_user_id_fk": {
+          "name": "telemetry_events_user_id_users_user_id_fk",
+          "tableFrom": "telemetry_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usages": {
+      "name": "usages",
+      "columns": {
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "usages_site_id_date_key_unique": {
+          "name": "usages_site_id_date_key_unique",
+          "columns": [
+            "site_id",
+            "date",
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "usages_site_id_sites_site_id_fk": {
+          "name": "usages_site_id_sites_site_id_fk",
+          "tableFrom": "usages",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_identities": {
+      "name": "user_identities",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_identities_email_idx": {
+          "name": "user_identities_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "user_identities_user_idx": {
+          "name": "user_identities_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "user_identities_pk": {
+          "name": "user_identities_pk",
+          "columns": [
+            "provider",
+            "provider_user_id"
+          ],
+          "isUnique": true
+        },
+        "user_identities_user_provider_unique": {
+          "name": "user_identities_user_provider_unique",
+          "columns": [
+            "user_id",
+            "provider"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_identities_user_id_users_user_id_fk": {
+          "name": "user_identities_user_id_users_user_id_fk",
+          "tableFrom": "user_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_sites": {
+      "name": "user_sites",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_level": {
+          "name": "permission_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_sites_user_id_site_id_unique": {
+          "name": "user_sites_user_id_site_id_unique",
+          "columns": [
+            "user_id",
+            "site_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_sites_user_id_users_user_id_fk": {
+          "name": "user_sites_user_id_users_user_id_fk",
+          "tableFrom": "user_sites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_sites_site_id_sites_site_id_fk": {
+          "name": "user_sites_site_id_sites_site_id_fk",
+          "tableFrom": "user_sites",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "analytics_range": {
+          "name": "analytics_range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analytics_period": {
+          "name": "analytics_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_indexing_oauth_id": {
+          "name": "last_indexing_oauth_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_team_id": {
+          "name": "current_team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gscdump_user_id": {
+          "name": "gscdump_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gscdump_api_key": {
+          "name": "gscdump_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_sub_unique": {
+          "name": "users_sub_unique",
+          "columns": [
+            "sub"
+          ],
+          "isUnique": true
+        },
+        "users_api_key_unique": {
+          "name": "users_api_key_unique",
+          "columns": [
+            "api_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "users_current_team_id_teams_team_id_fk": {
+          "name": "users_current_team_id_teams_team_id_fk",
+          "tableFrom": "users",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "current_team_id"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/layers/core/server/db/migrations/meta/_journal.json
+++ b/layers/core/server/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1786594043704,
       "tag": "0011_drop_team_gsc_credential_key",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1787460401958,
+      "tag": "0012_dataforseo_requests",
+      "breakpoints": true
     }
   ]
 }

--- a/layers/core/server/db/schema.ts
+++ b/layers/core/server/db/schema.ts
@@ -663,6 +663,35 @@ export const siteGroups = sqliteTable('site_groups', {
 export type ApiUsageSource = 'mcp' | 'rest' | 'internal'
 export type ApiUsageStatus = 'success' | 'error'
 
+/**
+ * One DataForSEO task per row: what asked for it, what it cost, what the
+ * provider said. The account is shared with nuxtseo.com; until this table
+ * existed (2026-08-23) the public tools spent credit with no record, and the
+ * month's billing export could not be attributed to a caller. Cost is the
+ * provider's own measured `cost` from the response envelope, in micro-USD,
+ * so sums reconcile against the invoice rather than an estimate.
+ */
+export const dataforseoRequests = sqliteTable('dataforseo_requests', {
+  dataforseoRequestId: integer('dataforseo_request_id').primaryKey({ autoIncrement: true }),
+  /** Which public tool or internal path fired the call. */
+  tool: text('tool').notNull(),
+  /** Provider endpoint path, e.g. `/serp/google/organic/live/advanced`. */
+  endpoint: text('endpoint').notNull(),
+  /** Tasks in the batch (live endpoints batch up to 100 per request). */
+  taskCount: integer('task_count').notNull().default(1),
+  /** HTTP status of the provider response. */
+  status: text('status', { enum: ['ok', 'http_error'] }).notNull(),
+  httpStatus: integer('http_status'),
+  /** Measured cost from the envelope, micro-USD. Null when the call failed. */
+  costUsdMicros: integer('cost_usd_micros'),
+  /** Hashed caller IP for anonymous attribution (tools are unauthenticated). */
+  ipHash: text('ip_hash'),
+  createdAt: integer('created_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
+}, t => ({
+  createdIdx: index('dataforseo_requests_created_idx').on(t.createdAt),
+  toolCreatedIdx: index('dataforseo_requests_tool_created_idx').on(t.tool, t.createdAt),
+}))
+
 export const apiUsageEvents = sqliteTable('pro_api_usage_events', {
   apiUsageEventId: integer('api_usage_event_id').primaryKey({ autoIncrement: true }),
   teamId: integer('team_id').notNull().references(() => teams.teamId, { onDelete: 'cascade' }),

--- a/layers/core/server/tsconfig.json
+++ b/layers/core/server/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["./tsconfig.extra.json", "../.nuxt/tsconfig.server.json"]
+  "extends": ["../.nuxt/tsconfig.server.json"]
 }

--- a/layers/core/server/tsconfig.json
+++ b/layers/core/server/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": ["../.nuxt/tsconfig.server.json"]
+  // Nearest-tsconfig for files under layers/core/server (vite:oxc resolves
+  // this per file). The layer has no `.nuxt` of its own — nothing prepares it
+  // standalone — so extend the ROOT generated server tsconfig, which exists
+  // after `nuxt prepare` (postinstall) locally and in CI.
+  "extends": ["../../../.nuxt/tsconfig.server.json"]
 }

--- a/layers/pro-saas/server/database/_surface.ts
+++ b/layers/pro-saas/server/database/_surface.ts
@@ -12,6 +12,7 @@
 export {
   adminEvents,
   apiUsageEvents,
+  dataforseoRequests,
   failedJobs,
   feedback,
   googleAccounts,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -348,6 +348,11 @@ export default defineNuxtConfig({
     dataforseo: {
       login: '',
       password: '',
+      // Daily ceiling (USD) for ALL DataForSEO tool spend combined, counted
+      // from the provider's measured per-response cost in the `cache` KV.
+      // Once spent, the public tools answer 429 for the rest of the UTC day.
+      // NUXT_DATAFORSEO_DAILY_BUDGET_USD.
+      dailyBudgetUsd: '5',
     },
     google: {
       adsClientId: '',

--- a/tests/dataforseo-spend.test.ts
+++ b/tests/dataforseo-spend.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The public tools spend a DataForSEO account shared with nuxtseo.com. Until
+// 2026-08-23 nothing recorded or bounded that spend. These scratch checks drive
+// the exported budget + ledger functions the route seams call.
+
+const inserted: Array<Record<string, unknown>> = []
+// The D1 ledger write is a side effect at the storage boundary; capture it
+// instead of booting drizzle against a binding no node test has.
+vi.mock('../layers/core/server/utils/drizzle', () => ({
+  useDrizzle: () => ({
+    insert: () => ({
+      values: (v: Record<string, unknown>) => {
+        inserted.push(v)
+        return Promise.resolve()
+      },
+    }),
+  }),
+  tables: { dataforseoRequests: 'dataforseo_requests' },
+}))
+
+const { checkDataForSeoBudget, recordDataForSeoSpend } = await import('../layers/core/server/app/services/dataforseo-spend')
+
+const USD = 1_000_000
+
+/** Real in-memory fixture of the counter surface nitro's cache storage provides. */
+function memoryStorage(): { getItem: (k: string) => Promise<unknown>, setItem: (k: string, v: number, o?: { ttl: number }) => Promise<void> } {
+  const store = new Map<string, number>()
+  return {
+    getItem: k => Promise.resolve(store.get(k) ?? null),
+    setItem: (k, v) => {
+      store.set(k, v)
+      return Promise.resolve()
+    },
+  }
+}
+
+function env(budgetUsd: number) {
+  return { budgetMicros: Math.round(budgetUsd * USD), storage: memoryStorage() }
+}
+
+const SERP = '/serp/google/organic/live/advanced'
+
+describe('dataforseo spend budget', () => {
+  beforeEach(() => {
+    inserted.length = 0
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('blocks once measured spend passes the daily ceiling', async () => {
+    const e = env(2)
+    await recordDataForSeoSpend(
+      { tool: 'check-index', endpoint: SERP, taskCount: 1 },
+      { httpStatus: 200, costUsdMicros: 1.5 * USD },
+      e,
+    )
+    await recordDataForSeoSpend(
+      { tool: 'bulk-check', endpoint: SERP, taskCount: 50 },
+      { httpStatus: 200, costUsdMicros: 0.75 * USD },
+      e,
+    )
+
+    const verdict = await checkDataForSeoBudget({ tool: 'check-index', endpoint: SERP, taskCount: 1 }, e)
+    expect(verdict.spentMicros).toBe(2.25 * USD)
+    expect(verdict.blocked, 'a $2.25 day against a $2 budget must refuse the next call').toBe(true)
+    expect(inserted).toHaveLength(2)
+    expect(inserted[0]).toMatchObject({ tool: 'check-index', costUsdMicros: 1.5 * USD, status: 'ok' })
+  })
+
+  it('predicts a batch cost from list price before the call is made', async () => {
+    const e = env(2)
+    const fresh = await checkDataForSeoBudget({ tool: 'bulk-check', endpoint: SERP, taskCount: 50 }, e)
+    expect(fresh.blocked, '50 tasks x $0.0015 list = $0.075, far under a fresh $2 day').toBe(false)
+
+    await recordDataForSeoSpend(
+      { tool: 'bulk-check', endpoint: SERP, taskCount: 50 },
+      { httpStatus: 200, costUsdMicros: 1.99 * USD },
+      e,
+    )
+    const next = await checkDataForSeoBudget({ tool: 'bulk-check', endpoint: SERP, taskCount: 50 }, e)
+    expect(next.blocked, 'a predicted $0.075 no longer fits under a $2 ceiling').toBe(true)
+  })
+
+  it('opens the gate when nothing is recorded (fresh day, broken KV)', async () => {
+    const verdict = await checkDataForSeoBudget({ tool: 'check-index', endpoint: SERP, taskCount: 1 }, env(5))
+    expect(verdict.blocked).toBe(false)
+    expect(verdict.spentMicros).toBe(0)
+  })
+
+  it('records failed transports at zero cost but never bills them', async () => {
+    const e = env(2)
+    await recordDataForSeoSpend(
+      { tool: 'check-index', endpoint: SERP, taskCount: 1 },
+      { httpStatus: 402, costUsdMicros: null },
+      e,
+    )
+    const verdict = await checkDataForSeoBudget({ tool: 'check-index', endpoint: SERP, taskCount: 1 }, e)
+    expect(verdict.spentMicros, 'a 402 charged nothing, so the day is still unspent').toBe(0)
+    expect(inserted[0]).toMatchObject({ status: 'http_error', httpStatus: 402, costUsdMicros: null })
+  })
+})


### PR DESCRIPTION
> Drafted by an agent (opencode, glm-5.3). Verified by tests, local migration apply, lint, typecheck — not yet deployed.

## Why

The public tools (`check-index`, `bulk-check` up to 50 URLs/request, `site-report`) spend the DataForSEO account shared with nuxtseo.com — the same account that went dry on 08-22 after a $222 month. Until now: no spend record, no ceiling, and `checkFreeToolRateLimit` was dead code called by zero endpoints (its per-minute CF binding is also not provisioned, and `check-index` carried a comment claiming an in-memory rate limit that never existed).

## What

1. **Ledger** — `dataforseo_requests` D1 table: one row per outbound batch with the provider's OWN measured cost (micro-USD, from the response envelope `cost` field), tool, endpoint, task count, HTTP status, hashed caller IP. Failed transports log at null cost (DataForSEO charges nothing) but still record the attempt — a 402 storm here is how a dry account shows itself.
2. **Budget gate** — shared daily ceiling across all tools, counted from measured cost in the `cache` KV. Pre-call the gate predicts batch cost from list price; post-call the counter records actual. `NUXT_DATAFORSEO_DAILY_BUDGET_USD`, default $5/day. Over budget → 429 "at capacity for today". A broken KV read opens the gate (fail-open) — the tools being up is worth more than the cents a broken read saves.
3. **Rate limit wired** — the existing `checkFreeToolRateLimit` (50/day per IP, KV) now actually runs on all three routes. The per-minute CF `RL_FREE_TOOLS` binding still needs provisioning (dashboard/API) — flagged, not silently ignored.
4. **Drive-by fix** — `layers/core/server/tsconfig.json` extended `./tsconfig.extra.json`, a file that never existed in git; it blocked any vitest test from importing core server code. Removed the dead extends entry.

Design: budget/ledger functions take an explicit `DataForSeoSpendEnv` (budget + storage) so the decision core is pure; routes build it from runtime config + nitro `cache` storage via `dataForSeoCallContext(tool, event)`.

## Verification

- `tests/dataforseo-spend.test.ts` — 4 behavior tests: gate blocks past ceiling, list-price prediction, fail-open on missing counter, failed transport bills $0
- Full suite 142/142, lint clean, typecheck clean, migration `0012` applies locally
- Reverse-guard: flipping the gate's comparison breaks test 1 and 2 (verified red before finalizing)

## After merge

- `pnpm db:migrate` (remote D1), then deploy
- Provision `RL_FREE_TOOLS` rate-limit namespace in wrangler.toml for the per-minute tier
- Companion work in nuxtseo.com PR #515: account-burn alert reading the shared account's balance — covers this repo too until keys are isolated