### PR TITLE
fix(dataforseo): answer a provider outage at the transport, not per route

### DIFF
--- a/apps/marketing/server/api/tools/check-index.post.ts
+++ b/apps/marketing/server/api/tools/check-index.post.ts
@@ -1,7 +1,6 @@
 import { checkUrlIndexed, dataForSeoCallContext } from '~~/layers/core/server/app/services/dataforseo'
 import { checkDataForSeoBudget } from '~~/layers/core/server/app/services/dataforseo-spend'
 import { checkFreeToolRateLimit } from '#layers/pro-saas/server/utils/rate-limit'
-import { runDataForSEORequest } from '../../../../../shared/dataforseo'
 
 export default defineEventHandler(async (event) => {
   await checkFreeToolRateLimit(event)
@@ -30,17 +29,10 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const outcome = await runDataForSEORequest(() => checkUrlIndexed(normalizedUrl, ctx))
-
-  if (outcome._tag === 'Unavailable') {
-    throw createError({
-      statusCode: 503,
-      message: 'Index status is temporarily unavailable. Please try again shortly.',
-    })
-  }
+  const result = await checkUrlIndexed(normalizedUrl, ctx)
 
   return {
-    ...outcome.value,
+    ...result,
     checkedAt: new Date().toISOString(),
   }
 })

--- a/layers/core/server/app/services/dataforseo.ts
+++ b/layers/core/server/app/services/dataforseo.ts
@@ -1,6 +1,12 @@
 import type { H3Event } from 'h3'
 import type { DataForSeoSpendEnv } from './dataforseo-spend'
-import { DATAFORSEO_RETRY_OPTIONS } from '../../../../../shared/dataforseo'
+import { createError } from 'h3'
+import {
+  DATAFORSEO_RETRY_OPTIONS,
+  DATAFORSEO_UNAVAILABLE_MESSAGE,
+  dataForSeoStatusCode,
+  isTransientDataForSeoFailure,
+} from '../../../../../shared/dataforseo'
 import { dataForSeoSpendEnv, recordDataForSeoSpend } from './dataforseo-spend'
 
 export interface DataForSeoCallContext extends DataForSeoSpendEnv {
@@ -98,16 +104,6 @@ export function tagDataForSeoTasks<T extends Record<string, unknown>>(
   }))
 }
 
-function errorHttpStatus(error: unknown): number {
-  if (!error || typeof error !== 'object')
-    return 0
-  if ('statusCode' in error && typeof error.statusCode === 'number')
-    return error.statusCode
-  if ('response' in error && error.response && typeof error.response === 'object' && 'status' in error.response && typeof error.response.status === 'number')
-    return error.response.status
-  return 0
-}
-
 interface DomainRankResult {
   items?: Array<{
     metrics?: { organic?: { etv?: number, count?: number } }
@@ -149,6 +145,10 @@ function getAuthHeader(credentials = getCredentials()): string {
  * `dataforseo_requests` ledger with the provider's measured cost. The meter is
  * best-effort and never fails the call: the budget GATE runs at the route seam
  * before the provider is reached.
+ *
+ * A provider outage is classified here rather than at each route, so no tool
+ * route can forget it: `/api/tools/bulk-check` and `/api/tools/site-report`
+ * both used to leak the raw `FetchError` as a 500 and file it in Sentry.
  */
 async function dataforseoFetch<T>(endpoint: string, body: Record<string, unknown>[], ctx?: DataForSeoCallContext): Promise<T> {
   const providerBody = tagDataForSeoTasks(body, ctx?.tool ?? 'internal', crypto.randomUUID())
@@ -174,7 +174,7 @@ async function dataforseoFetch<T>(endpoint: string, body: Record<string, unknown
     return data as T
   }
   catch (err) {
-    const httpStatus = errorHttpStatus(err)
+    const httpStatus = dataForSeoStatusCode(err) ?? 0
     if (ctx?.tool) {
       // Failed transport: no body, provider charges nothing, but the attempt
       // is still evidence — a 402 storm here is how the account running dry
@@ -185,6 +185,8 @@ async function dataforseoFetch<T>(endpoint: string, body: Record<string, unknown
         ctx,
       )
     }
+    if (isTransientDataForSeoFailure(err))
+      throw createError({ statusCode: 503, message: DATAFORSEO_UNAVAILABLE_MESSAGE, cause: err })
     throw err
   }
 }

--- a/shared/dataforseo.ts
+++ b/shared/dataforseo.ts
@@ -4,11 +4,9 @@ export const DATAFORSEO_RETRY_OPTIONS = {
   retryStatusCodes: [408, 409, 425, 429, 500, 502, 503, 504, 520, 521, 522, 523, 524],
 }
 
-type DataForSEORequestResult<T>
-  = | { _tag: 'Success', value: T }
-    | { _tag: 'Unavailable', statusCode: number }
+export const DATAFORSEO_UNAVAILABLE_MESSAGE = 'Search data is temporarily unavailable. Try again shortly.'
 
-function getStatusCode(error: unknown): number | undefined {
+export function dataForSeoStatusCode(error: unknown): number | undefined {
   if (!error || typeof error !== 'object')
     return undefined
 
@@ -27,14 +25,12 @@ function getStatusCode(error: unknown): number | undefined {
   return candidates.find(status => typeof status === 'number') as number | undefined
 }
 
-export function runDataForSEORequest<T>(request: () => Promise<T>): Promise<DataForSEORequestResult<T>> {
-  return request()
-    .then(value => ({ _tag: 'Success', value }) as const)
-    .catch((error: unknown) => {
-      const statusCode = getStatusCode(error)
-      if (statusCode === 429 || (statusCode !== undefined && statusCode >= 500))
-        return { _tag: 'Unavailable', statusCode } as const
-
-      return Promise.reject(error)
-    })
+/**
+ * True when the provider, or Cloudflare in front of it, was momentarily unable
+ * to answer. Every one of these has already exhausted `DATAFORSEO_RETRY_OPTIONS`,
+ * so the outage outlives a retry and belongs to the provider, not to this app.
+ */
+export function isTransientDataForSeoFailure(error: unknown): boolean {
+  const status = dataForSeoStatusCode(error)
+  return status === 429 || (status !== undefined && status >= 500)
 }

--- a/tests/dataforseo.test.ts
+++ b/tests/dataforseo.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it, vi } from 'vitest'
-import { checkUrlIndexed, tagDataForSeoTasks } from '../layers/core/server/app/services/dataforseo'
-import { DATAFORSEO_RETRY_OPTIONS, runDataForSEORequest } from '../shared/dataforseo'
+import { checkUrlIndexed, checkUrlsIndexed, tagDataForSeoTasks } from '../layers/core/server/app/services/dataforseo'
+import { DATAFORSEO_RETRY_OPTIONS, DATAFORSEO_UNAVAILABLE_MESSAGE } from '../shared/dataforseo'
+
+function callContext() {
+  return {
+    budgetMicros: 0,
+    credentials: { login: 'login', password: 'password' },
+    storage: {
+      getItem: async () => null,
+      setItem: () => Promise.resolve(),
+    },
+  }
+}
 
 describe('dataForSEO requests', () => {
   it('attributes every provider task to its app and target Site', () => {
@@ -43,17 +54,28 @@ describe('dataForSEO requests', () => {
     }))
   })
 
-  it('returns transient upstream errors as expected failures', async () => {
-    const outcome = await runDataForSEORequest(() => Promise.reject(
-      Object.assign(new Error('upstream unavailable'), { statusCode: 520 }),
-    ))
+  it('answers a transient provider outage with a 503', async () => {
+    const outcome = checkUrlIndexed('https://docs.example.com/guide', {
+      ...callContext(),
+      providerFetch: (() => Promise.reject(
+        Object.assign(new Error('upstream unavailable'), { statusCode: 520 }),
+      )) as unknown as typeof $fetch,
+    })
 
-    expect(outcome).toEqual({ _tag: 'Unavailable', statusCode: 520 })
+    await expect(outcome).rejects.toMatchObject({
+      statusCode: 503,
+      message: DATAFORSEO_UNAVAILABLE_MESSAGE,
+    })
   })
 
-  it('does not hide non-transient failures', async () => {
-    const error = Object.assign(new Error('unauthorized'), { statusCode: 401 })
+  it('keeps a credential failure at its own status', async () => {
+    const outcome = checkUrlsIndexed(['https://docs.example.com/guide'], {
+      ...callContext(),
+      providerFetch: (() => Promise.reject(
+        Object.assign(new Error('unauthorized'), { statusCode: 401 }),
+      )) as unknown as typeof $fetch,
+    })
 
-    await expect(runDataForSEORequest(() => Promise.reject(error))).rejects.toBe(error)
+    await expect(outcome).rejects.toMatchObject({ statusCode: 401 })
   })
 })


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

DataForSEO threw a Cloudflare 520 at `/api/tools/check-index` on 10 Aug and filed REQUEST-INDEXING-1. That one route got a `runDataForSEORequest` wrapper. The other two public tools never did, so `/api/tools/bulk-check` and `/api/tools/site-report` still let an upstream 5xx or 429 escape as a raw `FetchError`: the caller sees a 500, and Sentry files the provider's status under our name. Bulk check is the worst of the three, because a 520 halfway through the batch discards every URL already checked.

`dataforseoFetch` is the one transport every provider call goes through, so the outage is classified there now and a new tool route cannot forget it. The route-level wrapper is deleted.

Loose end I left alone: the 503 still reports to Sentry, since the server policy only drops 404. One issue per real outage seems right to me. If it turns noisy, `nuxtSentry.policy.dropServerStatus` is the place to change it.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).