### PR TITLE
chore: schedule the daily Sentry check-in

### DIFF
--- a/.github/harlan-agent.yml
+++ b/.github/harlan-agent.yml
@@ -11,7 +11,7 @@ routines:
   - name: sentry-checkin
     on:
       schedule:
-        - cron: "0 6 * * *"
+        - cron: '0 6 * * *'
     timezone: Australia/Sydney
     mode: report
     enabled: true

--- a/.github/harlan-agent.yml
+++ b/.github/harlan-agent.yml
@@ -1,0 +1,17 @@
+# Scheduled agent work for this repository.
+#
+# harlan-github-agent reads this file from the default branch only, and never
+# from a pull request head. It may set the schedule, the mode, and enabled. It
+# cannot name a command, a model, or any new authority.
+#
+# mode: report writes the run log and opens nothing. Switch to propose once the
+# run log reads well, and each finding becomes its own issue and pull request.
+version: 1
+routines:
+  - name: sentry-checkin
+    on:
+      schedule:
+        - cron: "0 6 * * *"
+    timezone: Australia/Sydney
+    mode: report
+    enabled: true


### PR DESCRIPTION
### ❓ Type of change

- [x] 🧹 Chore

### 📚 Description

Sentry issues on this site are only ever looked at when I go looking. This asks
harlan-github-agent to check the `request-indexing` Sentry project every morning at
06:00 Sydney time, so a new production error is triaged before I open the laptop
rather than whenever I next remember.

Starting in `report` mode. The routine writes what it found to a run log issue
and opens nothing else, so the first few mornings can be read before anything
acts on them. Switching to `propose` is a one word edit, and each finding then
becomes its own issue and pull request through the pipeline that already reviews
everything here.

The service reads this file from the default branch only, never from a pull
request head, and the file can set the schedule, the mode, and enabled. It cannot
name a command, a model, or any new authority.

Times are staggered across my sites so eight scans do not start at once and
queue behind each other.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).